### PR TITLE
chore: expand .gitignore to cover logs, keys, and OS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,24 @@
 node_modules/
 dist/
+.vite/
+
+# Environment
 .env
+.env.local
+.env.*.local
+
+# Data files
 *.db
 *.db-journal
-.vite/
 .machine-id
+
+# Logs
+*.log
+
+# Keys and secrets
+*.pem
+*.key
+
+# OS files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary

Add missing patterns to `.gitignore`:
- `*.log` — application log files
- `.env.local`, `.env.*.local` — local environment overrides
- `*.pem`, `*.key` — private keys
- `.DS_Store`, `Thumbs.db` — OS-specific files

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)