### PR TITLE
fix: use bracketed paste for Claude Code + resizable textarea

### DIFF
--- a/agent/src/terminal-server.ts
+++ b/agent/src/terminal-server.ts
@@ -19,7 +19,6 @@ const SESSION_READY_POLL_MS = 300;
 const SESSION_READY_TIMEOUT_MS = 5000;
 const PTY_INIT_DELAY_MS = 1000;
 const PTY_INPUT_BASE_DELAY_MS = 500;
-const PTY_INPUT_PER_CHAR_MS = 15; // extra delay per character for TUI apps
 const BRACKETED_PASTE_DELAY_MS = 100;
 const BACKUP_ENTER_DELAY_MS = 300;
 
@@ -262,19 +261,15 @@ function buildAttachCommand(multiplexer: "zellij" | "tmux", sessionName: string)
 // --- Send-text helpers ---
 
 /**
- * Send text via PTY attachment to a multiplexer session.
- * Spawns the python PTY helper, waits for init, then delegates to
- * the appropriate write strategy based on agent type.
+ * Send text via PTY attachment with bracketed paste mode.
+ * Uses escape sequences so the terminal handles the entire paste
+ * as one event instead of individual keystrokes.
  */
 async function sendViaPTY(
   attachCmd: string[],
   text: string,
-  agentType: AgentType | undefined,
   cleanEnv: Record<string, string | undefined>,
 ): Promise<void> {
-  // Send text via PTY attachment.
-  // For TUI apps (OpenCode), use a longer per-char delay since
-  // Bubble Tea processes characters as individual key events.
   const proc = Bun.spawn(["python3", PTY_HELPER, "120", "40", ...attachCmd], {
     stdin: "pipe",
     stdout: "pipe",
@@ -284,32 +279,15 @@ async function sendViaPTY(
 
   await new Promise((r) => setTimeout(r, PTY_INIT_DELAY_MS));
 
-  if (agentType === "opencode") {
-    await sendBracketedPaste(proc, text);
-  } else {
-    // Claude Code: write all at once (simple CLI prompt)
-    proc.stdin.write(`${text}\r`);
-    const inputDelay = PTY_INPUT_BASE_DELAY_MS + text.length * PTY_INPUT_PER_CHAR_MS;
-    await new Promise((r) => setTimeout(r, inputDelay));
-  }
-
-  proc.kill();
-}
-
-/**
- * Send text using bracketed paste mode for TUI apps (OpenCode / Bubble Tea).
- * Wraps the text in escape sequences so the TUI handles the entire paste
- * as one event instead of individual keystrokes.
- * \x1b[200~ = paste start, \x1b[201~ = paste end
- */
-async function sendBracketedPaste(proc: Subprocess, text: string): Promise<void> {
-  // Use bracketed paste mode — Bubble Tea handles the entire
-  // paste as one event instead of individual keystrokes.
+  // Bracketed paste mode for all agents — the terminal handles
+  // the entire paste as one event instead of individual keystrokes.
   // \x1b[200~ = paste start, \x1b[201~ = paste end
   proc.stdin.write(`\x1b[200~${text}\x1b[201~`);
   await new Promise((r) => setTimeout(r, BRACKETED_PASTE_DELAY_MS));
   proc.stdin.write("\r");
   await new Promise((r) => setTimeout(r, PTY_INPUT_BASE_DELAY_MS));
+
+  proc.kill();
 }
 
 /**
@@ -934,10 +912,9 @@ export function startTerminalServer(port: number, machineId: string): Server {
 
       // HTTP endpoint: send text to a multiplexer session
       //
-      // Uses native multiplexer commands (write-chars / send-keys) for reliable
-      // text delivery to both CLI prompts and TUI apps (OpenCode Bubble Tea).
-      // For multi-line text, falls back to PTY-based paste to handle bracketed
-      // paste mode correctly.
+      // Uses PTY attachment with bracketed paste mode for reliable text delivery
+      // to both CLI prompts (Claude Code) and TUI apps (OpenCode Bubble Tea).
+      // A backup Enter is sent via native multiplexer commands to ensure submission.
       if (url.pathname === "/api/send" && req.method === "POST") {
         try {
           const body = (await req.json()) as {
@@ -954,18 +931,15 @@ export function startTerminalServer(port: number, machineId: string): Server {
           const cleanEnv = cleanMultiplexerEnv();
           cleanEnv.TERM = "xterm-256color";
 
-          const isMultiline = body.text.includes("\n");
           log.info(
             `send: session=${body.session} mux=${body.multiplexer} agent=${body.agentType || "claude-code"} chars=${body.text.length}`,
           );
 
           const attachCmd = buildAttachCommand(body.multiplexer, body.session);
-          await sendViaPTY(attachCmd, body.text, body.agentType, cleanEnv);
+          await sendViaPTY(attachCmd, body.text, cleanEnv);
 
           // Backup Enter via native command in case PTY CR was swallowed
-          if (isMultiline) {
-            await sendBackupEnter(body.multiplexer, body.session, cleanEnv);
-          }
+          await sendBackupEnter(body.multiplexer, body.session, cleanEnv);
 
           log.debug("send: completed");
           return Response.json({ ok: true });

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -854,10 +854,9 @@ body {
   font-size: 13px;
   font-family: "SF Mono", "Fira Code", monospace;
   padding: 8px 10px;
-  resize: none;
+  resize: vertical;
   outline: none;
   min-height: 48px;
-  max-height: 200px;
 }
 
 .send-textarea:focus {


### PR DESCRIPTION
## Summary

- **Claude Code text sending fix**: Unified text sending to use bracketed paste mode (`\x1b[200~...\x1b[201~`) for all agent types, not just OpenCode. Previously Claude Code wrote text directly via PTY which caused the carriage return to be swallowed — requiring manual Enter in the TUI.
- **Backup Enter for all messages**: The backup Enter via native multiplexer command (`zellij action write 13` / `tmux send-keys Enter`) now fires for all messages, not just multiline, ensuring submission even when PTY CR is swallowed.
- **Resizable textarea**: Changed the send-message textarea from `resize: none` to `resize: vertical` and removed the `max-height: 200px` cap, so users can drag to expand the textarea for reviewing multi-line messages before sending.

## Test plan

- [x] All 139 existing tests pass
- [x] Biome lint/format clean (only pre-existing warning on unrelated line)
- [ ] Manual: send single-line message to Claude Code session → should auto-submit
- [ ] Manual: send multi-line message to Claude Code session → should auto-submit
- [ ] Manual: send message to OpenCode session → should still work as before
- [ ] Manual: grab textarea corner and resize vertically → should expand freely

🤖 Generated with [Claude Code](https://claude.com/claude-code)