### PR TITLE
test: expand test coverage for 9 untested modules

### DIFF
--- a/agent/src/providers/claude-code/hook-handler.test.ts
+++ b/agent/src/providers/claude-code/hook-handler.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, test } from "bun:test";
+import { handleClaudeHookEvent } from "./hook-handler";
+
+/** Factory helper: build a minimal valid Claude hook event payload. */
+function makeHookPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    session_id: "550e8400-e29b-41d4-a716-446655440000",
+    hook_event_name: "Stop",
+    ...overrides,
+  };
+}
+
+describe("handleClaudeHookEvent", () => {
+  describe("invalid payloads return null", () => {
+    test("null payload", () => {
+      expect(handleClaudeHookEvent(null)).toBeNull();
+    });
+
+    test("undefined payload", () => {
+      expect(handleClaudeHookEvent(undefined)).toBeNull();
+    });
+
+    test("numeric payload", () => {
+      expect(handleClaudeHookEvent(42)).toBeNull();
+    });
+
+    test("string payload", () => {
+      expect(handleClaudeHookEvent("not an object")).toBeNull();
+    });
+
+    test("boolean payload", () => {
+      expect(handleClaudeHookEvent(true)).toBeNull();
+    });
+
+    test("array payload", () => {
+      expect(handleClaudeHookEvent([1, 2, 3])).toBeNull();
+    });
+
+    test("empty object (missing required fields)", () => {
+      expect(handleClaudeHookEvent({})).toBeNull();
+    });
+
+    test("missing session_id", () => {
+      expect(handleClaudeHookEvent({ hook_event_name: "Stop" })).toBeNull();
+    });
+
+    test("missing hook_event_name", () => {
+      expect(handleClaudeHookEvent({ session_id: "s1" })).toBeNull();
+    });
+
+    test("session_id is a number instead of string", () => {
+      expect(handleClaudeHookEvent({ session_id: 123, hook_event_name: "Stop" })).toBeNull();
+    });
+
+    test("hook_event_name is a number instead of string", () => {
+      expect(handleClaudeHookEvent({ session_id: "s1", hook_event_name: 456 })).toBeNull();
+    });
+
+    test("session_id is null", () => {
+      expect(handleClaudeHookEvent({ session_id: null, hook_event_name: "Stop" })).toBeNull();
+    });
+
+    test("hook_event_name is null", () => {
+      expect(handleClaudeHookEvent({ session_id: "s1", hook_event_name: null })).toBeNull();
+    });
+
+    test("session_id is an empty string", () => {
+      expect(handleClaudeHookEvent(makeHookPayload({ session_id: "" }))).toBeNull();
+    });
+  });
+
+  describe("UserPromptSubmit sets working status", () => {
+    test("basic UserPromptSubmit", () => {
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "UserPromptSubmit" }));
+      expect(result).toEqual({
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        status: "working",
+        currentTool: undefined,
+      });
+    });
+  });
+
+  describe("PreToolUse sets working status with tool name", () => {
+    test("PreToolUse with tool_name", () => {
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "PreToolUse", tool_name: "Bash" }));
+      expect(result).toEqual({
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        status: "working",
+        currentTool: "Bash",
+      });
+    });
+
+    test("PreToolUse without tool_name leaves currentTool undefined", () => {
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "PreToolUse" }));
+      expect(result).toEqual({
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        status: "working",
+        currentTool: undefined,
+      });
+    });
+
+    test("PreToolUse with various tool names", () => {
+      for (const toolName of ["Edit", "Read", "Write", "Grep", "Glob", "WebSearch"]) {
+        const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "PreToolUse", tool_name: toolName }));
+        expect(result?.currentTool).toBe(toolName);
+        expect(result?.status).toBe("working");
+      }
+    });
+  });
+
+  describe("PostToolUse sets working status and clears tool", () => {
+    test("PostToolUse clears currentTool", () => {
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "PostToolUse", tool_name: "Bash" }));
+      expect(result).toEqual({
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        status: "working",
+        currentTool: undefined,
+      });
+    });
+
+    test("PostToolUse without tool_name also works", () => {
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "PostToolUse" }));
+      expect(result).toEqual({
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        status: "working",
+        currentTool: undefined,
+      });
+    });
+  });
+
+  describe("PostToolUseFailure sets working status and clears tool", () => {
+    test("PostToolUseFailure clears currentTool", () => {
+      const result = handleClaudeHookEvent(
+        makeHookPayload({ hook_event_name: "PostToolUseFailure", tool_name: "Bash" }),
+      );
+      expect(result).toEqual({
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        status: "working",
+        currentTool: undefined,
+      });
+    });
+
+    test("PostToolUseFailure without tool_name", () => {
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "PostToolUseFailure" }));
+      expect(result?.status).toBe("working");
+      expect(result?.currentTool).toBeUndefined();
+    });
+  });
+
+  describe("Stop sets awaiting_input status", () => {
+    test("Stop clears currentTool and sets awaiting_input", () => {
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "Stop" }));
+      expect(result).toEqual({
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        status: "awaiting_input",
+        currentTool: undefined,
+      });
+    });
+  });
+
+  describe("Notification maps status based on notification_type", () => {
+    test("permission_prompt sets action_required", () => {
+      const result = handleClaudeHookEvent(
+        makeHookPayload({
+          hook_event_name: "Notification",
+          notification_type: "permission_prompt",
+        }),
+      );
+      expect(result).toEqual({
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        status: "action_required",
+        currentTool: undefined,
+      });
+    });
+
+    test("question sets action_required", () => {
+      const result = handleClaudeHookEvent(
+        makeHookPayload({
+          hook_event_name: "Notification",
+          notification_type: "question",
+        }),
+      );
+      expect(result).toEqual({
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        status: "action_required",
+        currentTool: undefined,
+      });
+    });
+
+    test("other notification_type sets awaiting_input", () => {
+      const result = handleClaudeHookEvent(
+        makeHookPayload({
+          hook_event_name: "Notification",
+          notification_type: "info",
+        }),
+      );
+      expect(result?.status).toBe("awaiting_input");
+    });
+
+    test("missing notification_type sets awaiting_input", () => {
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "Notification" }));
+      expect(result?.status).toBe("awaiting_input");
+    });
+
+    test("undefined notification_type sets awaiting_input", () => {
+      const result = handleClaudeHookEvent(
+        makeHookPayload({
+          hook_event_name: "Notification",
+          notification_type: undefined,
+        }),
+      );
+      expect(result?.status).toBe("awaiting_input");
+    });
+  });
+
+  describe("SessionStart sets awaiting_input status", () => {
+    test("SessionStart returns awaiting_input", () => {
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "SessionStart" }));
+      expect(result).toEqual({
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        status: "awaiting_input",
+        currentTool: undefined,
+      });
+    });
+  });
+
+  describe("SessionEnd sets done status", () => {
+    test("SessionEnd returns done and clears currentTool", () => {
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "SessionEnd" }));
+      expect(result).toEqual({
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        status: "done",
+        currentTool: undefined,
+      });
+    });
+  });
+
+  describe("unknown hook_event_name defaults to awaiting_input", () => {
+    test("unknown event name returns awaiting_input", () => {
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "SomeUnknownEvent" }));
+      expect(result?.status).toBe("awaiting_input");
+    });
+
+    test("empty string hook_event_name returns awaiting_input", () => {
+      // empty string passes the type guard (typeof === "string") but hits the default case
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "", session_id: "s1" }));
+      // empty hook_event_name is still a valid string, so type guard passes but session_id
+      // check passes too — hits default switch branch
+      expect(result?.status).toBe("awaiting_input");
+    });
+
+    test("misspelled event name returns awaiting_input", () => {
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "userpromptsubmit" }));
+      expect(result?.status).toBe("awaiting_input");
+    });
+  });
+
+  describe("session ID passthrough", () => {
+    test("preserves the original session_id as sessionId", () => {
+      const result = handleClaudeHookEvent(
+        makeHookPayload({
+          session_id: "my-custom-session-id-123",
+          hook_event_name: "Stop",
+        }),
+      );
+      expect(result?.sessionId).toBe("my-custom-session-id-123");
+    });
+
+    test("handles UUID format session IDs", () => {
+      const result = handleClaudeHookEvent(
+        makeHookPayload({
+          session_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          hook_event_name: "SessionStart",
+        }),
+      );
+      expect(result?.sessionId).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    });
+  });
+
+  describe("extra fields in payload are ignored", () => {
+    test("payload with extra fields still works", () => {
+      const result = handleClaudeHookEvent({
+        session_id: "s1",
+        hook_event_name: "Stop",
+        extra_field: "some value",
+        another_field: 42,
+        nested: { deep: true },
+      });
+      expect(result).toEqual({
+        sessionId: "s1",
+        status: "awaiting_input",
+        currentTool: undefined,
+      });
+    });
+  });
+
+  describe("return value shape", () => {
+    test("result always includes sessionId, status, and currentTool", () => {
+      const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "SessionStart" }));
+      expect(result).not.toBeNull();
+      expect(result).toHaveProperty("sessionId");
+      expect(result).toHaveProperty("status");
+      expect(result).toHaveProperty("currentTool");
+    });
+
+    test("currentTool is defined only for PreToolUse", () => {
+      const withTool = handleClaudeHookEvent(makeHookPayload({ hook_event_name: "PreToolUse", tool_name: "Read" }));
+      expect(withTool?.currentTool).toBe("Read");
+
+      const events = [
+        "UserPromptSubmit",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "Stop",
+        "Notification",
+        "SessionStart",
+        "SessionEnd",
+      ];
+      for (const eventName of events) {
+        const result = handleClaudeHookEvent(makeHookPayload({ hook_event_name: eventName }));
+        expect(result?.currentTool).toBeUndefined();
+      }
+    });
+  });
+});

--- a/agent/src/providers/claude-code/message-parser.test.ts
+++ b/agent/src/providers/claude-code/message-parser.test.ts
@@ -1,0 +1,464 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type ClaudeMessageEntry, formatClaudeEntry } from "./message-parser";
+
+function makeEntry(overrides: Partial<ClaudeMessageEntry> = {}): ClaudeMessageEntry {
+  return {
+    type: "assistant",
+    sessionId: "test-session-id",
+    timestamp: "2026-03-19T10:00:00Z",
+    message: {
+      role: "assistant",
+      model: "claude-opus-4-6",
+      content: [{ type: "text", text: "Hello from the assistant." }],
+    },
+    ...overrides,
+  };
+}
+
+describe("formatClaudeEntry", () => {
+  test("formats string content", () => {
+    const entry = makeEntry({
+      type: "user",
+      message: { role: "user", content: "Hello world" },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.role).toBe("user");
+    expect(result.content).toBe("Hello world");
+    expect(result.toolUse).toBeUndefined();
+    expect(result.toolResult).toBeUndefined();
+  });
+
+  test("formats array content with a single text block", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "One paragraph" }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.content).toBe("One paragraph");
+  });
+
+  test("joins multiple text blocks with double newline", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "First paragraph" },
+          { type: "text", text: "Second paragraph" },
+        ],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.content).toBe("First paragraph\n\nSecond paragraph");
+  });
+
+  test("extracts tool_use blocks with name and id", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me read the file" },
+          { type: "tool_use", name: "Read", id: "tool_abc" },
+        ],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.content).toBe("Let me read the file");
+    expect(result.toolUse).toEqual([{ name: "Read", id: "tool_abc" }]);
+  });
+
+  test("extracts multiple tool_use blocks", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", name: "Read", id: "t1" },
+          { type: "tool_use", name: "Edit", id: "t2" },
+          { type: "tool_use", name: "Bash", id: "t3" },
+        ],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolUse).toHaveLength(3);
+    expect(result.toolUse?.[0]).toEqual({ name: "Read", id: "t1" });
+    expect(result.toolUse?.[1]).toEqual({ name: "Edit", id: "t2" });
+    expect(result.toolUse?.[2]).toEqual({ name: "Bash", id: "t3" });
+  });
+
+  test("skips tool_use blocks missing name", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "t1" }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolUse).toBeUndefined();
+  });
+
+  test("skips tool_use blocks missing id", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", name: "Read" }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolUse).toBeUndefined();
+  });
+
+  test("extracts tool_result with string content", () => {
+    const entry = makeEntry({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", content: "file contents here" }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolResult).toBe("file contents here");
+  });
+
+  test("truncates tool_result string content to 500 characters", () => {
+    const longContent = "a".repeat(600);
+    const entry = makeEntry({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", content: longContent }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolResult).toHaveLength(500);
+  });
+
+  test("uses [tool output] for tool_result with non-string content", () => {
+    const entry = makeEntry({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", content: { complex: "object" } }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolResult).toBe("[tool output]");
+  });
+
+  test("uses [tool output] for tool_result with undefined content", () => {
+    const entry = makeEntry({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result" }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolResult).toBe("[tool output]");
+  });
+
+  test("handles mixed text, tool_use, and tool_result blocks", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Analyzing the code" },
+          { type: "tool_use", name: "Grep", id: "grep_1" },
+          { type: "tool_result", content: "match found on line 42" },
+          { type: "text", text: "Found the issue" },
+        ],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.content).toBe("Analyzing the code\n\nFound the issue");
+    expect(result.toolUse).toEqual([{ name: "Grep", id: "grep_1" }]);
+    expect(result.toolResult).toBe("match found on line 42");
+  });
+
+  test("returns empty content when content is undefined", () => {
+    const entry = makeEntry({
+      message: { role: "assistant" },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.content).toBe("");
+    expect(result.toolUse).toBeUndefined();
+    expect(result.toolResult).toBeUndefined();
+  });
+
+  test("returns empty content for empty array", () => {
+    const entry = makeEntry({
+      message: { role: "assistant", content: [] },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.content).toBe("");
+    expect(result.toolUse).toBeUndefined();
+    expect(result.toolResult).toBeUndefined();
+  });
+
+  test("returns empty content for non-string non-array content", () => {
+    const entry = makeEntry({
+      message: { role: "assistant", content: 42 },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.content).toBe("");
+  });
+
+  test("preserves timestamp from entry", () => {
+    const ts = "2026-01-15T08:30:00Z";
+    const entry = makeEntry({ timestamp: ts });
+    const result = formatClaudeEntry(entry);
+    expect(result.timestamp).toBe(ts);
+  });
+
+  test("preserves model from message", () => {
+    const entry = makeEntry({
+      message: { role: "assistant", model: "claude-sonnet-4-5-20250514", content: "hi" },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.model).toBe("claude-sonnet-4-5-20250514");
+  });
+
+  test("model is undefined when not present in message", () => {
+    const entry = makeEntry({
+      type: "user",
+      message: { role: "user", content: "hello" },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.model).toBeUndefined();
+  });
+
+  test("uses entry.type as the role in the output", () => {
+    const entry = makeEntry({ type: "user" });
+    const result = formatClaudeEntry(entry);
+    expect(result.role).toBe("user");
+  });
+
+  test("handles content blocks with unrecognized types gracefully", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [
+          { type: "image", source: "data:image/png;base64,..." },
+          { type: "text", text: "Here is the result" },
+        ],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.content).toBe("Here is the result");
+    expect(result.toolUse).toBeUndefined();
+    expect(result.toolResult).toBeUndefined();
+  });
+
+  test("handles text block with non-string text property", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: 123 }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.content).toBe("");
+  });
+
+  test("handles empty string content", () => {
+    const entry = makeEntry({
+      message: { role: "user", content: "" },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.content).toBe("");
+  });
+
+  test("tool_result exactly at 500 characters is not truncated", () => {
+    const exactContent = "b".repeat(500);
+    const entry = makeEntry({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", content: exactContent }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolResult).toHaveLength(500);
+    expect(result.toolResult).toBe(exactContent);
+  });
+});
+
+describe("getClaudeSessionMessages", () => {
+  let tempDir: string;
+  let projectsDir: string;
+
+  function writeJsonlFile(sessionId: string, entries: unknown[]): void {
+    const content = entries.map((e) => JSON.stringify(e)).join("\n");
+    writeFileSync(join(projectsDir, `${sessionId}.jsonl`), content);
+  }
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "claude-msg-parser-test-"));
+    projectsDir = join(tempDir, ".claude", "projects", "test-project");
+    mkdirSync(projectsDir, { recursive: true });
+
+    // Mock node:os to return our temp dir as homedir
+    mock.module("node:os", () => ({
+      homedir: () => tempDir,
+      tmpdir,
+    }));
+  });
+
+  afterEach(() => {
+    mock.restore();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("returns messages for a valid session", async () => {
+    const { getClaudeSessionMessages } = await import("./message-parser");
+
+    const sessionId = "session-abc-123";
+    writeJsonlFile(sessionId, [
+      makeEntry({ type: "user", sessionId, message: { role: "user", content: "Hello" } }),
+      makeEntry({ type: "assistant", sessionId, message: { role: "assistant", content: "Hi there" } }),
+    ]);
+
+    const result = await getClaudeSessionMessages(sessionId, 0, 50);
+    expect(result.messages).toHaveLength(2);
+    expect(result.total).toBe(2);
+    expect(result.hasMore).toBe(false);
+    expect(result.messages[0].content).toBe("Hello");
+    expect(result.messages[1].content).toBe("Hi there");
+  });
+
+  test("throws when session file is not found", async () => {
+    const { getClaudeSessionMessages } = await import("./message-parser");
+    expect(getClaudeSessionMessages("nonexistent-session", 0, 50)).rejects.toThrow("Session not found");
+  });
+
+  test("filters out non-user/assistant entries", async () => {
+    const { getClaudeSessionMessages } = await import("./message-parser");
+
+    const sessionId = "session-filter-test";
+    writeJsonlFile(sessionId, [
+      { type: "file-history-snapshot", sessionId, timestamp: "2026-01-01T00:00:00Z", message: {} },
+      makeEntry({ type: "user", sessionId, message: { role: "user", content: "Question" } }),
+      { type: "system", sessionId, timestamp: "2026-01-01T00:00:01Z", message: { role: "system" } },
+      makeEntry({ type: "assistant", sessionId, message: { role: "assistant", content: "Answer" } }),
+    ]);
+
+    const result = await getClaudeSessionMessages(sessionId, 0, 50);
+    expect(result.messages).toHaveLength(2);
+    expect(result.total).toBe(2);
+    expect(result.messages[0].content).toBe("Question");
+    expect(result.messages[1].content).toBe("Answer");
+  });
+
+  test("skips malformed JSONL lines", async () => {
+    const { getClaudeSessionMessages } = await import("./message-parser");
+
+    const sessionId = "session-malformed";
+    const content = [
+      JSON.stringify(makeEntry({ type: "user", sessionId, message: { role: "user", content: "Valid" } })),
+      "this is not valid json{{{",
+      JSON.stringify(
+        makeEntry({ type: "assistant", sessionId, message: { role: "assistant", content: "Also valid" } }),
+      ),
+    ].join("\n");
+    writeFileSync(join(projectsDir, `${sessionId}.jsonl`), content);
+
+    const result = await getClaudeSessionMessages(sessionId, 0, 50);
+    expect(result.messages).toHaveLength(2);
+    expect(result.total).toBe(2);
+  });
+
+  test("handles pagination with offset and limit", async () => {
+    const { getClaudeSessionMessages } = await import("./message-parser");
+
+    const sessionId = "session-pagination";
+    const entries = Array.from({ length: 10 }, (_, i) =>
+      makeEntry({
+        type: i % 2 === 0 ? "user" : "assistant",
+        sessionId,
+        message: { role: i % 2 === 0 ? "user" : "assistant", content: `Message ${i}` },
+      }),
+    );
+    writeJsonlFile(sessionId, entries);
+
+    // paginateFromEnd with offset=0, limit=3 returns last 3
+    const page1 = await getClaudeSessionMessages(sessionId, 0, 3);
+    expect(page1.messages).toHaveLength(3);
+    expect(page1.total).toBe(10);
+    expect(page1.hasMore).toBe(true);
+    expect(page1.messages[0].content).toBe("Message 7");
+    expect(page1.messages[2].content).toBe("Message 9");
+
+    // paginateFromEnd with offset=3, limit=3 returns next 3
+    const page2 = await getClaudeSessionMessages(sessionId, 3, 3);
+    expect(page2.messages).toHaveLength(3);
+    expect(page2.hasMore).toBe(true);
+    expect(page2.messages[0].content).toBe("Message 4");
+    expect(page2.messages[2].content).toBe("Message 6");
+  });
+
+  test("handles empty file gracefully", async () => {
+    const { getClaudeSessionMessages } = await import("./message-parser");
+
+    const sessionId = "session-empty";
+    writeFileSync(join(projectsDir, `${sessionId}.jsonl`), "");
+
+    const result = await getClaudeSessionMessages(sessionId, 0, 50);
+    expect(result.messages).toHaveLength(0);
+    expect(result.total).toBe(0);
+    expect(result.hasMore).toBe(false);
+  });
+
+  test("formats tool_use entries correctly through the full pipeline", async () => {
+    const { getClaudeSessionMessages } = await import("./message-parser");
+
+    const sessionId = "session-tools";
+    writeJsonlFile(sessionId, [
+      makeEntry({
+        type: "assistant",
+        sessionId,
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Reading file" },
+            { type: "tool_use", name: "Read", id: "tool_xyz" },
+          ],
+        },
+      }),
+    ]);
+
+    const result = await getClaudeSessionMessages(sessionId, 0, 50);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].content).toBe("Reading file");
+    expect(result.messages[0].toolUse).toEqual([{ name: "Read", id: "tool_xyz" }]);
+  });
+
+  test("hasMore is false when all entries fit within limit", async () => {
+    const { getClaudeSessionMessages } = await import("./message-parser");
+
+    const sessionId = "session-no-more";
+    writeJsonlFile(sessionId, [
+      makeEntry({ type: "user", sessionId, message: { role: "user", content: "One" } }),
+      makeEntry({ type: "assistant", sessionId, message: { role: "assistant", content: "Two" } }),
+    ]);
+
+    const result = await getClaudeSessionMessages(sessionId, 0, 50);
+    expect(result.hasMore).toBe(false);
+  });
+
+  test("file with only non-user/assistant entries returns empty messages", async () => {
+    const { getClaudeSessionMessages } = await import("./message-parser");
+
+    const sessionId = "session-no-messages";
+    writeJsonlFile(sessionId, [
+      { type: "system", sessionId, timestamp: "2026-01-01T00:00:00Z", message: { role: "system" } },
+      { type: "file-history-snapshot", sessionId, timestamp: "2026-01-01T00:00:01Z", message: {} },
+    ]);
+
+    const result = await getClaudeSessionMessages(sessionId, 0, 50);
+    expect(result.messages).toHaveLength(0);
+    expect(result.total).toBe(0);
+  });
+});

--- a/agent/src/providers/claude-code/process-mapper.test.ts
+++ b/agent/src/providers/claude-code/process-mapper.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test";
+import { extractClaudeSessionIdFromArgs, matchSessionByBirthTime, type SessionCandidate } from "./process-mapper";
+
+// NOTE: findSessionCandidates is not tested here because it performs real file
+// I/O (readdir, stat, Bun.spawn) against the user's Claude projects directory.
+// Testing it properly would require either mocking the filesystem or creating
+// temporary fixture directories. A future integration test could cover it.
+
+describe("extractClaudeSessionIdFromArgs", () => {
+  test("extracts UUID from --resume flag with full path binary", () => {
+    const args = "/home/user/.local/bin/claude --resume 550e8400-e29b-41d4-a716-446655440000";
+    expect(extractClaudeSessionIdFromArgs(args)).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  test("extracts UUID when --resume is the only flag", () => {
+    const args = "claude --resume abcdef01-2345-6789-abcd-ef0123456789";
+    expect(extractClaudeSessionIdFromArgs(args)).toBe("abcdef01-2345-6789-abcd-ef0123456789");
+  });
+
+  test("extracts UUID when --resume appears with other flags before it", () => {
+    const args = "claude --model claude-opus-4-6 --resume 11111111-2222-3333-4444-555555555555";
+    expect(extractClaudeSessionIdFromArgs(args)).toBe("11111111-2222-3333-4444-555555555555");
+  });
+
+  test("extracts UUID when --resume has flags after it", () => {
+    const args = "claude --resume 550e8400-e29b-41d4-a716-446655440000 --model claude-opus-4-6";
+    expect(extractClaudeSessionIdFromArgs(args)).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  test("extracts UUID with multiple spaces between --resume and UUID", () => {
+    const args = "claude --resume   550e8400-e29b-41d4-a716-446655440000";
+    expect(extractClaudeSessionIdFromArgs(args)).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  test("returns undefined when no --resume flag is present", () => {
+    expect(extractClaudeSessionIdFromArgs("claude")).toBeUndefined();
+  });
+
+  test("returns undefined for bare binary path without flags", () => {
+    expect(extractClaudeSessionIdFromArgs("/usr/bin/claude")).toBeUndefined();
+  });
+
+  test("returns undefined when --resume is followed by a non-UUID value", () => {
+    expect(extractClaudeSessionIdFromArgs("claude --resume not-a-uuid")).toBeUndefined();
+  });
+
+  test("returns undefined when --resume has a truncated UUID (too short)", () => {
+    expect(extractClaudeSessionIdFromArgs("claude --resume 550e8400-e29b-41d4")).toBeUndefined();
+  });
+
+  test("returns undefined when --resume value contains uppercase hex", () => {
+    // The regex only matches lowercase hex [0-9a-f]
+    expect(extractClaudeSessionIdFromArgs("claude --resume 550E8400-E29B-41D4-A716-446655440000")).toBeUndefined();
+  });
+
+  test("returns undefined for empty string args", () => {
+    expect(extractClaudeSessionIdFromArgs("")).toBeUndefined();
+  });
+
+  test("returns undefined when --resume appears without a value", () => {
+    expect(extractClaudeSessionIdFromArgs("claude --resume")).toBeUndefined();
+  });
+
+  test("does not match -resume (single dash)", () => {
+    expect(extractClaudeSessionIdFromArgs("claude -resume 550e8400-e29b-41d4-a716-446655440000")).toBeUndefined();
+  });
+
+  test("extracts only the first UUID when --resume appears multiple times", () => {
+    const args = "claude --resume aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee --resume 11111111-2222-3333-4444-555555555555";
+    expect(extractClaudeSessionIdFromArgs(args)).toBe("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+  });
+});
+
+describe("matchSessionByBirthTime", () => {
+  const now = Date.now();
+  const BIRTHTIME_MATCH_WINDOW_MS = 120_000; // 2 minutes, must match the constant in the source
+
+  test("matches a session created close to the process start time", () => {
+    const candidates: SessionCandidate[] = [
+      { id: "session-new", birthtimeMs: now - 5_000 },
+      { id: "session-old", birthtimeMs: now - 3_600_000 },
+    ];
+    const processStartMs = now - 10_000;
+
+    const result = matchSessionByBirthTime(candidates, processStartMs, new Set());
+    expect(result).toBe("session-new");
+  });
+
+  test("returns undefined when no candidates are within the time window", () => {
+    const candidates: SessionCandidate[] = [{ id: "session-old", birthtimeMs: now - 3_600_000 }];
+    const processStartMs = now - 60_000;
+
+    const result = matchSessionByBirthTime(candidates, processStartMs, new Set());
+    expect(result).toBeUndefined();
+  });
+
+  test("picks the candidate with the smallest time difference", () => {
+    const candidates: SessionCandidate[] = [
+      { id: "session-close", birthtimeMs: now - 8_000 },
+      { id: "session-far", birthtimeMs: now - 90_000 },
+    ];
+    const processStartMs = now - 10_000;
+    // session-close: diff=2s, session-far: diff=80s — both within 2min window
+
+    const result = matchSessionByBirthTime(candidates, processStartMs, new Set());
+    expect(result).toBe("session-close");
+  });
+
+  test("skips candidates whose IDs are in the claimed set", () => {
+    const candidates: SessionCandidate[] = [
+      { id: "session-a", birthtimeMs: now - 5_000 },
+      { id: "session-b", birthtimeMs: now - 8_000 },
+    ];
+    const processStartMs = now - 6_000;
+    const claimed = new Set(["session-a"]);
+
+    const result = matchSessionByBirthTime(candidates, processStartMs, claimed);
+    expect(result).toBe("session-b");
+  });
+
+  test("returns undefined when all candidates are claimed", () => {
+    const candidates: SessionCandidate[] = [{ id: "session-a", birthtimeMs: now - 5_000 }];
+    const processStartMs = now - 6_000;
+    const claimed = new Set(["session-a"]);
+
+    const result = matchSessionByBirthTime(candidates, processStartMs, claimed);
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined for an empty candidates array", () => {
+    const result = matchSessionByBirthTime([], now, new Set());
+    expect(result).toBeUndefined();
+  });
+
+  test("does not match when process started far before the session was created", () => {
+    // Process started 24h ago, but the JSONL was created 1h ago
+    const candidates: SessionCandidate[] = [{ id: "todays-session", birthtimeMs: now - 3_600_000 }];
+    const processStartMs = now - 86_400_000;
+
+    const result = matchSessionByBirthTime(candidates, processStartMs, new Set());
+    expect(result).toBeUndefined();
+  });
+
+  test("does not match when session was created far before the process started", () => {
+    // JSONL created 1h ago, process started just now
+    const candidates: SessionCandidate[] = [{ id: "old-session", birthtimeMs: now - 3_600_000 }];
+    const processStartMs = now;
+
+    const result = matchSessionByBirthTime(candidates, processStartMs, new Set());
+    expect(result).toBeUndefined();
+  });
+
+  test("matches at exactly the boundary of the time window", () => {
+    // diff = BIRTHTIME_MATCH_WINDOW_MS - 1 (just inside the window)
+    const candidates: SessionCandidate[] = [
+      {
+        id: "boundary-session",
+        birthtimeMs: now - (BIRTHTIME_MATCH_WINDOW_MS - 1),
+      },
+    ];
+    const processStartMs = now;
+
+    const result = matchSessionByBirthTime(candidates, processStartMs, new Set());
+    expect(result).toBe("boundary-session");
+  });
+
+  test("does not match at exactly the boundary of the time window (equal)", () => {
+    // diff = BIRTHTIME_MATCH_WINDOW_MS exactly — uses strict < so should NOT match
+    const candidates: SessionCandidate[] = [
+      {
+        id: "boundary-session",
+        birthtimeMs: now - BIRTHTIME_MATCH_WINDOW_MS,
+      },
+    ];
+    const processStartMs = now;
+
+    const result = matchSessionByBirthTime(candidates, processStartMs, new Set());
+    expect(result).toBeUndefined();
+  });
+
+  test("matches when birth time is slightly after process start (session created after process)", () => {
+    // Process started 10s ago, session created 5s ago — diff = 5s
+    const candidates: SessionCandidate[] = [{ id: "after-session", birthtimeMs: now - 5_000 }];
+    const processStartMs = now - 10_000;
+
+    const result = matchSessionByBirthTime(candidates, processStartMs, new Set());
+    expect(result).toBe("after-session");
+  });
+
+  test("matches when birth time equals process start time exactly", () => {
+    const candidates: SessionCandidate[] = [{ id: "exact-session", birthtimeMs: now }];
+    const processStartMs = now;
+
+    const result = matchSessionByBirthTime(candidates, processStartMs, new Set());
+    expect(result).toBe("exact-session");
+  });
+
+  test("simulates two processes each matching their own session", () => {
+    const candidates: SessionCandidate[] = [
+      { id: "session-early", birthtimeMs: now - 7_200_000 },
+      { id: "session-late", birthtimeMs: now - 60_000 },
+    ];
+    const claimed = new Set<string>();
+
+    // Newer process matches newer session
+    const processB = now - 55_000;
+    const matchB = matchSessionByBirthTime(candidates, processB, claimed);
+    expect(matchB).toBe("session-late");
+    if (matchB) claimed.add(matchB);
+
+    // Older process matches older session (session-late is now claimed)
+    const processA = now - 7_190_000;
+    const matchA = matchSessionByBirthTime(candidates, processA, claimed);
+    expect(matchA).toBe("session-early");
+  });
+
+  test("handles single candidate that is claimed", () => {
+    const candidates: SessionCandidate[] = [{ id: "only-one", birthtimeMs: now }];
+    const result = matchSessionByBirthTime(candidates, now, new Set(["only-one"]));
+    expect(result).toBeUndefined();
+  });
+
+  test("handles many candidates and picks the closest unclaimed one", () => {
+    const candidates: SessionCandidate[] = [
+      { id: "s1", birthtimeMs: now - 1_000 },
+      { id: "s2", birthtimeMs: now - 2_000 },
+      { id: "s3", birthtimeMs: now - 3_000 },
+      { id: "s4", birthtimeMs: now - 50_000 },
+      { id: "s5", birthtimeMs: now - 100_000 },
+    ];
+    const processStartMs = now - 2_500;
+    // s1: diff=1500, s2: diff=500, s3: diff=500, s4: diff=47500, s5: diff=97500
+    // s2 has diff=500, s3 has diff=500 — s2 appears first and will be set as best first
+    const claimed = new Set(["s2"]);
+
+    const result = matchSessionByBirthTime(candidates, processStartMs, claimed);
+    expect(result).toBe("s3");
+  });
+});

--- a/agent/src/providers/claude-code/session-discovery.test.ts
+++ b/agent/src/providers/claude-code/session-discovery.test.ts
@@ -1,0 +1,440 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  CLAUDE_PROJECTS_DIR,
+  type ClaudeJsonlEntry,
+  deleteClaudeSessionData,
+  discoverClaudeSessions,
+  parseClaudeSession,
+  pathToProjectDir,
+} from "./session-discovery";
+
+// ---------------------------------------------------------------------------
+// Factory helpers
+// ---------------------------------------------------------------------------
+
+function makeJsonlEntry(overrides: Partial<ClaudeJsonlEntry> = {}): ClaudeJsonlEntry {
+  return {
+    type: "assistant",
+    sessionId: "550e8400-e29b-41d4-a716-446655440000",
+    slug: "test-slug",
+    cwd: "/home/user/project",
+    gitBranch: "main",
+    version: "2.1.70",
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "assistant",
+      model: "claude-opus-4-6",
+      content: [{ type: "text", text: "Hello from Claude." }],
+    },
+    ...overrides,
+  };
+}
+
+function toJsonl(entries: Array<Record<string, unknown>>): string {
+  return entries.map((e) => JSON.stringify(e)).join("\n");
+}
+
+async function writeTempJsonl(dir: string, filename: string, content: string): Promise<string> {
+  const filePath = join(dir, filename);
+  await writeFile(filePath, content);
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// CLAUDE_PROJECTS_DIR
+// ---------------------------------------------------------------------------
+
+describe("CLAUDE_PROJECTS_DIR", () => {
+  test("points to ~/.claude/projects", () => {
+    expect(CLAUDE_PROJECTS_DIR).toEndWith(join(".claude", "projects"));
+    expect(CLAUDE_PROJECTS_DIR).toStartWith("/");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pathToProjectDir
+// ---------------------------------------------------------------------------
+
+describe("pathToProjectDir", () => {
+  test("replaces slashes with hyphens", () => {
+    expect(pathToProjectDir("/home/user/project")).toBe("-home-user-project");
+  });
+
+  test("handles root path", () => {
+    expect(pathToProjectDir("/")).toBe("-");
+  });
+
+  test("handles deeply nested path", () => {
+    expect(pathToProjectDir("/a/b/c/d/e")).toBe("-a-b-c-d-e");
+  });
+
+  test("handles path without leading slash", () => {
+    // The regex replaces ALL slashes, and the leading hyphen replace is a no-op
+    // since there's no leading slash to create a leading hyphen
+    expect(pathToProjectDir("home/user/project")).toBe("home-user-project");
+  });
+
+  test("handles empty string", () => {
+    expect(pathToProjectDir("")).toBe("");
+  });
+
+  test("preserves hyphens already in the path", () => {
+    expect(pathToProjectDir("/home/user/my-project")).toBe("-home-user-my-project");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseClaudeSession
+// ---------------------------------------------------------------------------
+
+describe("parseClaudeSession", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(require("node:os").tmpdir(), "agent-town-sd-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("parses a valid JSONL file into SessionInfo", async () => {
+    const entry = makeJsonlEntry();
+    const filePath = await writeTempJsonl(tempDir, "session.jsonl", toJsonl([entry]));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).not.toBeNull();
+    expect(session?.sessionId).toBe("550e8400-e29b-41d4-a716-446655440000");
+    expect(session?.agentType).toBe("claude-code");
+    expect(session?.slug).toBe("test-slug");
+    expect(session?.cwd).toBe("/home/user/project");
+    expect(session?.projectPath).toBe("/home/user/project");
+    expect(session?.projectName).toBe("project");
+    expect(session?.gitBranch).toBe("main");
+    expect(session?.model).toBe("claude-opus-4-6");
+    expect(session?.version).toBe("2.1.70");
+  });
+
+  test("returns null for empty file", async () => {
+    const filePath = await writeTempJsonl(tempDir, "empty.jsonl", "");
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).toBeNull();
+  });
+
+  test("returns null when all lines are malformed JSON", async () => {
+    const filePath = await writeTempJsonl(tempDir, "bad.jsonl", "not json\nalso not json\n{broken");
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).toBeNull();
+  });
+
+  test("returns null when entries lack cwd field", async () => {
+    const content = toJsonl([
+      { type: "assistant", sessionId: "abc", message: { role: "assistant" }, timestamp: new Date().toISOString() },
+    ]);
+    const filePath = await writeTempJsonl(tempDir, "no-cwd.jsonl", content);
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).toBeNull();
+  });
+
+  test("skips malformed lines and uses the last valid entry", async () => {
+    const validEntry = makeJsonlEntry({ sessionId: "valid-session" });
+    const content = `${JSON.stringify(validEntry)}\n{broken json}\nnot json at all`;
+    const filePath = await writeTempJsonl(tempDir, "mixed.jsonl", content);
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).not.toBeNull();
+    expect(session?.sessionId).toBe("valid-session");
+  });
+
+  test("uses first entry with cwd as projectPath", async () => {
+    const entries = [
+      makeJsonlEntry({ cwd: "/home/user/root-project" }),
+      makeJsonlEntry({ cwd: "/home/user/root-project/subdir" }),
+    ];
+    const filePath = await writeTempJsonl(tempDir, "multi.jsonl", toJsonl(entries));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).not.toBeNull();
+    expect(session?.projectPath).toBe("/home/user/root-project");
+    expect(session?.cwd).toBe("/home/user/root-project/subdir");
+  });
+
+  test("falls back to lastEntry.cwd when early entries lack cwd", async () => {
+    const content = toJsonl([
+      { type: "file-history-snapshot", messageId: "snap", snapshot: {} },
+      makeJsonlEntry({ cwd: "/home/user/fallback" }),
+    ]);
+    const filePath = await writeTempJsonl(tempDir, "fallback.jsonl", content);
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).not.toBeNull();
+    expect(session?.projectPath).toBe("/home/user/fallback");
+  });
+
+  test("uses sessionId prefix as slug when slug is absent", async () => {
+    const entry = makeJsonlEntry({ slug: undefined, sessionId: "abcdef12-3456-7890-abcd-ef1234567890" });
+    const filePath = await writeTempJsonl(tempDir, "no-slug.jsonl", toJsonl([entry]));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).not.toBeNull();
+    expect(session?.slug).toBe("abcdef12");
+  });
+
+  test("filters out HEAD as git branch", async () => {
+    const entry = makeJsonlEntry({ gitBranch: "HEAD" });
+    const filePath = await writeTempJsonl(tempDir, "head-branch.jsonl", toJsonl([entry]));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).not.toBeNull();
+    expect(session?.gitBranch).toBe("");
+  });
+
+  test("sets empty gitBranch when gitBranch is undefined", async () => {
+    const entry = makeJsonlEntry({ gitBranch: undefined });
+    const filePath = await writeTempJsonl(tempDir, "no-branch.jsonl", toJsonl([entry]));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).not.toBeNull();
+    expect(session?.gitBranch).toBe("");
+  });
+
+  test("uses file mtime as lastActivity when entry has no timestamp", async () => {
+    const entry = makeJsonlEntry({ timestamp: "" });
+    const mtimeMs = Date.now() - 5000;
+    const filePath = await writeTempJsonl(tempDir, "no-ts.jsonl", toJsonl([entry]));
+
+    const session = await parseClaudeSession(filePath, mtimeMs);
+    expect(session).not.toBeNull();
+    expect(session?.lastActivity).toBe(new Date(mtimeMs).toISOString());
+  });
+
+  test("uses entry timestamp as lastActivity when present", async () => {
+    const ts = "2026-01-15T10:00:00.000Z";
+    const entry = makeJsonlEntry({ timestamp: ts });
+    const filePath = await writeTempJsonl(tempDir, "with-ts.jsonl", toJsonl([entry]));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).not.toBeNull();
+    expect(session?.lastActivity).toBe(ts);
+  });
+
+  // -- Status detection (detectClaudeStatus) --
+
+  test("detects working status when mtime is less than 30 seconds ago", async () => {
+    const entry = makeJsonlEntry();
+    const filePath = await writeTempJsonl(tempDir, "working.jsonl", toJsonl([entry]));
+    const mtimeMs = Date.now() - 10_000; // 10 seconds ago
+
+    const session = await parseClaudeSession(filePath, mtimeMs);
+    expect(session).not.toBeNull();
+    expect(session?.status).toBe("working");
+  });
+
+  test("detects awaiting_input status when mtime is between 30s and 60s ago", async () => {
+    const entry = makeJsonlEntry();
+    const filePath = await writeTempJsonl(tempDir, "awaiting.jsonl", toJsonl([entry]));
+    const mtimeMs = Date.now() - 45_000; // 45 seconds ago
+
+    const session = await parseClaudeSession(filePath, mtimeMs);
+    expect(session).not.toBeNull();
+    expect(session?.status).toBe("awaiting_input");
+  });
+
+  test("detects idle status when mtime is between 1min and 10min ago", async () => {
+    const entry = makeJsonlEntry();
+    const filePath = await writeTempJsonl(tempDir, "idle.jsonl", toJsonl([entry]));
+    const mtimeMs = Date.now() - 5 * 60 * 1000; // 5 minutes ago
+
+    const session = await parseClaudeSession(filePath, mtimeMs);
+    expect(session).not.toBeNull();
+    expect(session?.status).toBe("idle");
+  });
+
+  test("detects done status when mtime is more than 10 minutes ago", async () => {
+    const entry = makeJsonlEntry();
+    const filePath = await writeTempJsonl(tempDir, "done.jsonl", toJsonl([entry]));
+    const mtimeMs = Date.now() - 15 * 60 * 1000; // 15 minutes ago
+
+    const session = await parseClaudeSession(filePath, mtimeMs);
+    expect(session).not.toBeNull();
+    expect(session?.status).toBe("done");
+  });
+
+  // -- summarizeLastMessage --
+
+  test("summarizes text content from content array", async () => {
+    const entry = makeJsonlEntry({
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "This is the response text." }],
+      },
+    });
+    const filePath = await writeTempJsonl(tempDir, "text.jsonl", toJsonl([entry]));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session?.lastMessage).toBe("This is the response text.");
+  });
+
+  test("summarizes string content directly", async () => {
+    const entry = makeJsonlEntry({
+      message: { role: "assistant", content: "Direct string content" },
+    });
+    const filePath = await writeTempJsonl(tempDir, "str.jsonl", toJsonl([entry]));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session?.lastMessage).toBe("Direct string content");
+  });
+
+  test("truncates long text content to 120 chars", async () => {
+    const longText = "A".repeat(200);
+    const entry = makeJsonlEntry({
+      message: { role: "assistant", content: longText },
+    });
+    const filePath = await writeTempJsonl(tempDir, "long.jsonl", toJsonl([entry]));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session?.lastMessage).toHaveLength(120);
+  });
+
+  test("summarizes tool_use as [Tool: name]", async () => {
+    const entry = makeJsonlEntry({
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", name: "Bash", input: {} }],
+      },
+    });
+    const filePath = await writeTempJsonl(tempDir, "tool.jsonl", toJsonl([entry]));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session?.lastMessage).toBe("[Tool: Bash]");
+  });
+
+  test("summarizes tool_result as waiting for response", async () => {
+    const entry = makeJsonlEntry({
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", content: "output", tool_use_id: "toolu_123" }],
+      },
+    });
+    const filePath = await writeTempJsonl(tempDir, "tool-result.jsonl", toJsonl([entry]));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session?.lastMessage).toBe("[Waiting for response...]");
+  });
+
+  test("returns empty string for missing content", async () => {
+    const entry = makeJsonlEntry({
+      message: { role: "assistant" },
+    });
+    const filePath = await writeTempJsonl(tempDir, "no-content.jsonl", toJsonl([entry]));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session?.lastMessage).toBe("");
+  });
+
+  test("returns null for nonexistent file", async () => {
+    const session = await parseClaudeSession("/tmp/nonexistent-file.jsonl", Date.now());
+    expect(session).toBeNull();
+  });
+
+  test("handles file with only whitespace", async () => {
+    const filePath = await writeTempJsonl(tempDir, "whitespace.jsonl", "   \n  \n  ");
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).toBeNull();
+  });
+
+  test("reads last valid entry from a long file", async () => {
+    // Build a file with many entries, last one has a distinct sessionId
+    const entries: Array<Record<string, unknown>> = [];
+    for (let i = 0; i < 250; i++) {
+      entries.push(makeJsonlEntry({ sessionId: `session-${i}` }));
+    }
+    entries.push(makeJsonlEntry({ sessionId: "session-final" }));
+    const filePath = await writeTempJsonl(tempDir, "long-file.jsonl", toJsonl(entries));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).not.toBeNull();
+    expect(session?.sessionId).toBe("session-final");
+  });
+
+  test("selects last entry scanning from bottom (skips entries without cwd)", async () => {
+    const entries = [
+      makeJsonlEntry({ sessionId: "first", cwd: "/home/user/project" }),
+      {
+        type: "assistant",
+        sessionId: "no-cwd-entry",
+        message: { role: "assistant" },
+        timestamp: new Date().toISOString(),
+      },
+    ];
+    const filePath = await writeTempJsonl(tempDir, "bottom-scan.jsonl", toJsonl(entries));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).not.toBeNull();
+    // Should find "first" because the second entry lacks cwd
+    expect(session?.sessionId).toBe("first");
+  });
+
+  test("only considers user or assistant type entries for lastEntry", async () => {
+    const entries = [
+      makeJsonlEntry({ type: "user", cwd: "/home/user/project", sessionId: "user-entry" }),
+      {
+        type: "system",
+        sessionId: "system-entry",
+        cwd: "/home/user/project",
+        message: { role: "system" },
+        timestamp: new Date().toISOString(),
+      },
+    ];
+    const filePath = await writeTempJsonl(tempDir, "type-filter.jsonl", toJsonl(entries));
+
+    const session = await parseClaudeSession(filePath, Date.now());
+    expect(session).not.toBeNull();
+    // "system" type is not user/assistant, so it falls back to "user-entry"
+    expect(session?.sessionId).toBe("user-entry");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverClaudeSessions
+// ---------------------------------------------------------------------------
+
+describe("discoverClaudeSessions", () => {
+  // discoverClaudeSessions hardcodes CLAUDE_PROJECTS_DIR so we cannot
+  // easily redirect it to a temp directory without mocking. Instead, we test
+  // that it gracefully handles missing/empty directories and returns an array.
+
+  test("returns an array without throwing (graceful fallback)", async () => {
+    const sessions = await discoverClaudeSessions();
+    expect(Array.isArray(sessions)).toBe(true);
+  });
+
+  test("every returned session has agentType claude-code", async () => {
+    const sessions = await discoverClaudeSessions();
+    for (const s of sessions) {
+      expect(s.agentType).toBe("claude-code");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteClaudeSessionData
+// ---------------------------------------------------------------------------
+
+describe("deleteClaudeSessionData", () => {
+  // deleteClaudeSessionData also hardcodes CLAUDE_PROJECTS_DIR, so we test
+  // that it returns false for a nonexistent session ID without throwing.
+
+  test("returns false for a session ID that does not exist", async () => {
+    const result = await deleteClaudeSessionData("nonexistent-session-id-12345");
+    expect(result).toBe(false);
+  });
+});

--- a/agent/src/providers/opencode/event-handler.test.ts
+++ b/agent/src/providers/opencode/event-handler.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, test } from "bun:test";
+
+import { handleOpenCodeEvent, isSSEActive } from "./event-handler";
+
+/**
+ * Tests for event-handler.ts
+ *
+ * Covers:
+ * - handleOpenCodeEvent: edge cases and event types NOT covered by opencode.test.ts
+ * - isSSEActive: exported boolean accessor
+ *
+ * Skipped:
+ * - startOpenCodeEventStream: async with SSE network I/O (requires live OpenCode server)
+ * - mapSSEEvent: private function, not exported (indirectly tested via startOpenCodeEventStream)
+ */
+
+// --- handleOpenCodeEvent: event types not covered in opencode.test.ts ---
+
+describe("handleOpenCodeEvent edge cases", () => {
+  describe("uncovered event types", () => {
+    test("handles message.updated as working", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "ses_abc",
+        event_type: "message.updated",
+        agent_type: "opencode",
+      });
+      expect(result).toEqual({
+        sessionId: "ses_abc",
+        status: "working",
+        currentTool: undefined,
+      });
+    });
+
+    test("handles permission.replied as working", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "ses_abc",
+        event_type: "permission.replied",
+        agent_type: "opencode",
+      });
+      expect(result).toEqual({
+        sessionId: "ses_abc",
+        status: "working",
+        currentTool: undefined,
+      });
+    });
+
+    test("handles tool.execute.before without tool_name", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "ses_abc",
+        event_type: "tool.execute.before",
+        agent_type: "opencode",
+      });
+      expect(result).toEqual({
+        sessionId: "ses_abc",
+        status: "working",
+        currentTool: undefined,
+      });
+    });
+  });
+
+  describe("invalid payload shapes", () => {
+    test("returns null for undefined", () => {
+      expect(handleOpenCodeEvent(undefined)).toBeNull();
+    });
+
+    test("returns null for a number", () => {
+      expect(handleOpenCodeEvent(42)).toBeNull();
+    });
+
+    test("returns null for a string", () => {
+      expect(handleOpenCodeEvent("session.idle")).toBeNull();
+    });
+
+    test("returns null for a boolean", () => {
+      expect(handleOpenCodeEvent(true)).toBeNull();
+    });
+
+    test("returns null for an array", () => {
+      expect(
+        handleOpenCodeEvent([
+          {
+            session_id: "ses_abc",
+            event_type: "session.idle",
+            agent_type: "opencode",
+          },
+        ]),
+      ).toBeNull();
+    });
+  });
+
+  describe("missing or wrong-typed fields", () => {
+    test("returns null when agent_type is missing", () => {
+      expect(
+        handleOpenCodeEvent({
+          session_id: "ses_abc",
+          event_type: "session.idle",
+        }),
+      ).toBeNull();
+    });
+
+    test("returns null when agent_type is not opencode", () => {
+      expect(
+        handleOpenCodeEvent({
+          session_id: "ses_abc",
+          event_type: "session.idle",
+          agent_type: "claude-code",
+        }),
+      ).toBeNull();
+    });
+
+    test("returns null when session_id is missing entirely", () => {
+      expect(
+        handleOpenCodeEvent({
+          event_type: "session.idle",
+          agent_type: "opencode",
+        }),
+      ).toBeNull();
+    });
+
+    test("returns null when event_type is missing entirely", () => {
+      expect(
+        handleOpenCodeEvent({
+          session_id: "ses_abc",
+          agent_type: "opencode",
+        }),
+      ).toBeNull();
+    });
+
+    test("returns null when session_id is a number instead of string", () => {
+      expect(
+        handleOpenCodeEvent({
+          session_id: 123,
+          event_type: "session.idle",
+          agent_type: "opencode",
+        }),
+      ).toBeNull();
+    });
+
+    test("returns null when event_type is a number instead of string", () => {
+      expect(
+        handleOpenCodeEvent({
+          session_id: "ses_abc",
+          event_type: 42,
+          agent_type: "opencode",
+        }),
+      ).toBeNull();
+    });
+
+    test("returns null when agent_type is a number instead of string", () => {
+      expect(
+        handleOpenCodeEvent({
+          session_id: "ses_abc",
+          event_type: "session.idle",
+          agent_type: 1,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("extra fields do not interfere", () => {
+    test("ignores unrecognized extra properties", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "ses_xyz",
+        event_type: "session.idle",
+        agent_type: "opencode",
+        extra_field: "should be ignored",
+        nested: { deep: true },
+      });
+      expect(result).toEqual({
+        sessionId: "ses_xyz",
+        status: "awaiting_input",
+        currentTool: undefined,
+      });
+    });
+
+    test("tool.execute.after ignores tool_name if present", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "ses_abc",
+        event_type: "tool.execute.after",
+        agent_type: "opencode",
+        tool_name: "bash",
+      });
+      // tool_name is only captured on tool.execute.before, not after
+      expect(result).toEqual({
+        sessionId: "ses_abc",
+        status: "working",
+        currentTool: undefined,
+      });
+    });
+  });
+
+  describe("session_id variations", () => {
+    test("works with standard opencode session ID format", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "ses_30163a6c1ffeYDGuDOrp0nH9vG",
+        event_type: "session.created",
+        agent_type: "opencode",
+      });
+      expect(result).toEqual({
+        sessionId: "ses_30163a6c1ffeYDGuDOrp0nH9vG",
+        status: "awaiting_input",
+        currentTool: undefined,
+      });
+    });
+
+    test("works with UUID-style session ID", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "550e8400-e29b-41d4-a716-446655440000",
+        event_type: "session.error",
+        agent_type: "opencode",
+      });
+      expect(result).toEqual({
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        status: "error",
+        currentTool: undefined,
+      });
+    });
+
+    test("works with minimal single-character session ID", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "x",
+        event_type: "session.deleted",
+        agent_type: "opencode",
+      });
+      expect(result).toEqual({
+        sessionId: "x",
+        status: "done",
+        currentTool: undefined,
+      });
+    });
+  });
+
+  describe("status mapping completeness", () => {
+    test("session.created maps to awaiting_input", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "s",
+        event_type: "session.created",
+        agent_type: "opencode",
+      });
+      expect(result?.status).toBe("awaiting_input");
+    });
+
+    test("session.idle maps to awaiting_input", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "s",
+        event_type: "session.idle",
+        agent_type: "opencode",
+      });
+      expect(result?.status).toBe("awaiting_input");
+    });
+
+    test("session.deleted maps to done", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "s",
+        event_type: "session.deleted",
+        agent_type: "opencode",
+      });
+      expect(result?.status).toBe("done");
+    });
+
+    test("session.error maps to error", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "s",
+        event_type: "session.error",
+        agent_type: "opencode",
+      });
+      expect(result?.status).toBe("error");
+    });
+
+    test("tool.execute.before maps to working", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "s",
+        event_type: "tool.execute.before",
+        agent_type: "opencode",
+      });
+      expect(result?.status).toBe("working");
+    });
+
+    test("tool.execute.after maps to working", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "s",
+        event_type: "tool.execute.after",
+        agent_type: "opencode",
+      });
+      expect(result?.status).toBe("working");
+    });
+
+    test("message.updated maps to working", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "s",
+        event_type: "message.updated",
+        agent_type: "opencode",
+      });
+      expect(result?.status).toBe("working");
+    });
+
+    test("permission.asked maps to action_required", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "s",
+        event_type: "permission.asked",
+        agent_type: "opencode",
+      });
+      expect(result?.status).toBe("action_required");
+    });
+
+    test("permission.replied maps to working", () => {
+      const result = handleOpenCodeEvent({
+        session_id: "s",
+        event_type: "permission.replied",
+        agent_type: "opencode",
+      });
+      expect(result?.status).toBe("working");
+    });
+  });
+
+  describe("unknown and edge-case event types", () => {
+    test("returns null for event type with similar prefix", () => {
+      expect(
+        handleOpenCodeEvent({
+          session_id: "s",
+          event_type: "session.updated",
+          agent_type: "opencode",
+        }),
+      ).toBeNull();
+    });
+
+    test("returns null for event type with wrong casing", () => {
+      expect(
+        handleOpenCodeEvent({
+          session_id: "s",
+          event_type: "Session.Idle",
+          agent_type: "opencode",
+        }),
+      ).toBeNull();
+    });
+
+    test("returns null for empty event_type", () => {
+      expect(
+        handleOpenCodeEvent({
+          session_id: "s",
+          event_type: "",
+          agent_type: "opencode",
+        }),
+      ).toBeNull();
+    });
+
+    test("returns null for event type with trailing whitespace", () => {
+      expect(
+        handleOpenCodeEvent({
+          session_id: "s",
+          event_type: "session.idle ",
+          agent_type: "opencode",
+        }),
+      ).toBeNull();
+    });
+  });
+});
+
+// --- isSSEActive ---
+
+describe("isSSEActive", () => {
+  test("returns false by default when no stream has been started", () => {
+    expect(isSSEActive()).toBe(false);
+  });
+
+  test("returns a boolean value", () => {
+    expect(typeof isSSEActive()).toBe("boolean");
+  });
+});
+
+// --- startOpenCodeEventStream ---
+// Skipped: requires a live OpenCode server with SSE support.
+// It uses getOpenCodeClient() which connects to http://127.0.0.1:4096,
+// then subscribes to client.event.subscribe() for SSE streaming.
+// Integration testing would require mocking the SDK client.

--- a/agent/src/providers/opencode/message-parser.test.ts
+++ b/agent/src/providers/opencode/message-parser.test.ts
@@ -1,0 +1,841 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// --- Test data factories ---
+
+interface SdkPart {
+  id: string;
+  type: string;
+  text?: string;
+  name?: string;
+  toolName?: string;
+  toolCallId?: string;
+}
+
+interface SdkMessageInfo {
+  role: string;
+  time: { created: string };
+  modelID?: string;
+  providerID?: string;
+}
+
+interface SdkMessage {
+  info: SdkMessageInfo;
+  parts: SdkPart[];
+}
+
+function makeSdkMessage(overrides: Partial<SdkMessage> = {}): SdkMessage {
+  return {
+    info: {
+      role: "assistant",
+      time: { created: "2026-03-19T10:00:00.000Z" },
+      ...overrides.info,
+    },
+    parts: overrides.parts ?? [{ id: "p1", type: "text", text: "Hello from SDK" }],
+  };
+}
+
+function makeSdkUserMessage(text = "User question"): SdkMessage {
+  return makeSdkMessage({
+    info: { role: "user", time: { created: "2026-03-19T09:59:00.000Z" } },
+    parts: [{ id: "p0", type: "text", text }],
+  });
+}
+
+// --- Mocking setup ---
+// mock.module requires the absolute path with .ts extension to correctly
+// intercept transitive imports from message-parser.ts.
+
+const PROVIDER_DIR = import.meta.dir;
+const SESSION_DISCOVERY_PATH = join(PROVIDER_DIR, "session-discovery.ts");
+const SDK_CLIENT_PATH = join(PROVIDER_DIR, "sdk-client.ts");
+
+let tempDir: string;
+let dbPath: string;
+let mockClient: { session: { messages: ReturnType<typeof mock> } } | null;
+
+// Mock the sdk-client module so we control what getOpenCodeClient returns
+mock.module(SDK_CLIENT_PATH, () => ({
+  getOpenCodeClient: async () => mockClient,
+  resetOpenCodeClient: () => {
+    mockClient = null;
+  },
+}));
+
+// Initial mock for session-discovery (will be re-mocked in beforeEach with correct path)
+mock.module(SESSION_DISCOVERY_PATH, () => ({
+  OPENCODE_DB_PATH: "",
+}));
+
+// Now import the function under test AFTER mocking
+const { getOpenCodeSessionMessages } = await import("./message-parser");
+
+describe("getOpenCodeSessionMessages", () => {
+  beforeEach(async () => {
+    mockClient = null;
+    tempDir = await mkdtemp(join(tmpdir(), "opencode-msg-test-"));
+    dbPath = join(tempDir, "opencode.db");
+
+    // Re-mock session-discovery with the current temp db path
+    mock.module(SESSION_DISCOVERY_PATH, () => ({
+      OPENCODE_DB_PATH: dbPath,
+    }));
+  });
+
+  afterEach(async () => {
+    mockClient = null;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // --- Helper to set up SQLite test database ---
+
+  function createTestDb(): Database {
+    const db = new Database(dbPath);
+    db.run(`CREATE TABLE IF NOT EXISTS message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL
+    )`);
+    db.run(`CREATE TABLE IF NOT EXISTS part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      data TEXT NOT NULL
+    )`);
+    return db;
+  }
+
+  function insertMessage(
+    db: Database,
+    id: string,
+    sessionId: string,
+    timeCreated: number,
+    data: Record<string, unknown>,
+  ): void {
+    db.run("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)", [
+      id,
+      sessionId,
+      timeCreated,
+      JSON.stringify(data),
+    ]);
+  }
+
+  function insertPart(db: Database, id: string, messageId: string, data: Record<string, unknown>): void {
+    db.run("INSERT INTO part (id, message_id, data) VALUES (?, ?, ?)", [id, messageId, JSON.stringify(data)]);
+  }
+
+  // =====================
+  // SDK path tests
+  // =====================
+
+  describe("via SDK", () => {
+    test("returns formatted messages from SDK client", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkUserMessage("What is 2+2?"),
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+            modelID: "claude-opus-4-6",
+            providerID: "anthropic",
+          },
+          parts: [{ id: "p1", type: "text", text: "The answer is 4." }],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+
+      expect(result.total).toBe(2);
+      expect(result.messages).toHaveLength(2);
+      expect(result.hasMore).toBe(false);
+
+      expect(result.messages[0].role).toBe("user");
+      expect(result.messages[0].content).toBe("What is 2+2?");
+      expect(result.messages[0].timestamp).toBe("2026-03-19T09:59:00.000Z");
+
+      expect(result.messages[1].role).toBe("assistant");
+      expect(result.messages[1].content).toBe("The answer is 4.");
+      expect(result.messages[1].model).toBe("anthropic/claude-opus-4-6");
+    });
+
+    test("filters out system role messages", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: { role: "system", time: { created: "2026-03-19T09:58:00.000Z" } },
+          parts: [{ id: "s1", type: "text", text: "System prompt" }],
+        }),
+        makeSdkUserMessage("Hello"),
+        makeSdkMessage(),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.total).toBe(2);
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[0].role).toBe("user");
+      expect(result.messages[1].role).toBe("assistant");
+    });
+
+    test("handles tool-invocation parts", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+          },
+          parts: [
+            { id: "p1", type: "text", text: "Let me read that file." },
+            { id: "p2", type: "tool-invocation", name: "Read", toolCallId: "tc_001" },
+          ],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.messages[0].content).toBe("Let me read that file.");
+      expect(result.messages[0].toolUse).toEqual([{ name: "Read", id: "tc_001" }]);
+    });
+
+    test("handles tool type parts with toolName field", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+          },
+          parts: [
+            {
+              id: "p1",
+              type: "tool",
+              toolName: "Edit",
+              toolCallId: "tc_002",
+            } as SdkPart,
+          ],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.messages[0].toolUse).toEqual([{ name: "Edit", id: "tc_002" }]);
+    });
+
+    test("falls back to part.id when toolCallId is missing", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+          },
+          parts: [{ id: "fallback-id", type: "tool-invocation", name: "Bash" }],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.messages[0].toolUse).toEqual([{ name: "Bash", id: "fallback-id" }]);
+    });
+
+    test("falls back to 'unknown' when tool name fields are missing", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+          },
+          parts: [{ id: "p1", type: "tool-invocation" }],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.messages[0].toolUse).toEqual([{ name: "unknown", id: "p1" }]);
+    });
+
+    test("joins multiple text parts with double newline", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+          },
+          parts: [
+            { id: "p1", type: "text", text: "First paragraph." },
+            { id: "p2", type: "text", text: "Second paragraph." },
+          ],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.messages[0].content).toBe("First paragraph.\n\nSecond paragraph.");
+    });
+
+    test("returns empty content when no text parts exist", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+          },
+          parts: [{ id: "p1", type: "tool-invocation", name: "Bash", toolCallId: "tc1" }],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.messages[0].content).toBe("");
+      expect(result.messages[0].toolUse).toEqual([{ name: "Bash", id: "tc1" }]);
+    });
+
+    test("omits toolUse when no tool parts exist", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+          },
+          parts: [{ id: "p1", type: "text", text: "Just text, no tools." }],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.messages[0].toolUse).toBeUndefined();
+    });
+
+    test("sets model to modelID only when providerID is missing", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+            modelID: "gpt-4o",
+          },
+          parts: [{ id: "p1", type: "text", text: "Hi" }],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.messages[0].model).toBe("gpt-4o");
+    });
+
+    test("sets model to undefined when modelID is missing", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+          },
+          parts: [{ id: "p1", type: "text", text: "Hi" }],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.messages[0].model).toBeUndefined();
+    });
+
+    test("paginates from end with offset and limit", async () => {
+      const sdkMessages: SdkMessage[] = Array.from({ length: 5 }, (_, i) =>
+        makeSdkMessage({
+          info: {
+            role: i % 2 === 0 ? "user" : "assistant",
+            time: { created: `2026-03-19T10:0${i}:00.000Z` },
+          },
+          parts: [{ id: `p${i}`, type: "text", text: `Message ${i}` }],
+        }),
+      );
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      // Get last 2 messages (offset=0, limit=2) — should return messages 3 and 4
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 2);
+      expect(result.total).toBe(5);
+      expect(result.messages).toHaveLength(2);
+      expect(result.hasMore).toBe(true);
+      expect(result.messages[0].content).toBe("Message 3");
+      expect(result.messages[1].content).toBe("Message 4");
+    });
+
+    test("paginates with offset to get earlier messages", async () => {
+      const sdkMessages: SdkMessage[] = Array.from({ length: 5 }, (_, i) =>
+        makeSdkMessage({
+          info: {
+            role: i % 2 === 0 ? "user" : "assistant",
+            time: { created: `2026-03-19T10:0${i}:00.000Z` },
+          },
+          parts: [{ id: `p${i}`, type: "text", text: `Message ${i}` }],
+        }),
+      );
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      // Skip last 2, get 2 more (offset=2, limit=2) — should return messages 1 and 2
+      const result = await getOpenCodeSessionMessages("ses_test123", 2, 2);
+      expect(result.total).toBe(5);
+      expect(result.messages).toHaveLength(2);
+      expect(result.hasMore).toBe(true);
+      expect(result.messages[0].content).toBe("Message 1");
+      expect(result.messages[1].content).toBe("Message 2");
+    });
+
+    test("hasMore is false when all messages fit", async () => {
+      const sdkMessages: SdkMessage[] = [makeSdkUserMessage("Hi"), makeSdkMessage()];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 100);
+      expect(result.hasMore).toBe(false);
+      expect(result.total).toBe(2);
+    });
+
+    test("throws when SDK returns no data and SQLite has no matching session", async () => {
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: undefined })),
+        },
+      };
+
+      // Create empty database so SQLite path runs but finds no messages for this session
+      const db = createTestDb();
+      db.close();
+
+      // SDK path throws "Session not found", falls back to SQLite which returns empty
+      // but wait — SDK throws, then SQLite finds 0 messages and returns {messages:[], total:0}
+      // Actually re-reading the code: if data is undefined, it throws Error("Session not found")
+      // which triggers the catch block => resetOpenCodeClient() => falls back to SQLite
+      // SQLite will find 0 rows for ses_missing => returns {messages:[], total:0, hasMore:false}
+      const result = await getOpenCodeSessionMessages("ses_missing", 0, 10);
+      expect(result.total).toBe(0);
+      expect(result.messages).toHaveLength(0);
+    });
+
+    test("handles empty parts array", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+          },
+          parts: [],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].content).toBe("");
+      expect(result.messages[0].toolUse).toBeUndefined();
+    });
+
+    test("skips text parts with empty text", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+          },
+          parts: [
+            { id: "p1", type: "text", text: "" },
+            { id: "p2", type: "text", text: "Actual content" },
+          ],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      // Empty text is falsy, so only "Actual content" is included
+      expect(result.messages[0].content).toBe("Actual content");
+    });
+
+    test("falls back to SQLite when SDK throws an error", async () => {
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.reject(new Error("Connection refused"))),
+        },
+      };
+
+      // Set up SQLite fallback
+      const db = createTestDb();
+      const now = Date.now();
+      insertMessage(db, "msg1", "ses_fallback", now, { role: "user" });
+      insertPart(db, "part1", "msg1", { type: "text", text: "Fallback question" });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_fallback", 0, 10);
+      expect(result.total).toBe(1);
+      expect(result.messages[0].content).toBe("Fallback question");
+    });
+  });
+
+  // =====================
+  // SQLite fallback tests
+  // =====================
+
+  describe("via SQLite fallback", () => {
+    test("returns formatted messages from SQLite", async () => {
+      const db = createTestDb();
+      const baseTime = new Date("2026-03-19T10:00:00.000Z").getTime();
+
+      insertMessage(db, "msg1", "ses_abc", baseTime, { role: "user" });
+      insertPart(db, "part1", "msg1", { type: "text", text: "Hello from user" });
+
+      insertMessage(db, "msg2", "ses_abc", baseTime + 1000, {
+        role: "assistant",
+        modelID: "claude-opus-4-6",
+        providerID: "anthropic",
+      });
+      insertPart(db, "part2", "msg2", { type: "text", text: "Hello from assistant" });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+
+      expect(result.total).toBe(2);
+      expect(result.messages).toHaveLength(2);
+      expect(result.hasMore).toBe(false);
+
+      expect(result.messages[0].role).toBe("user");
+      expect(result.messages[0].content).toBe("Hello from user");
+      expect(result.messages[0].timestamp).toBe(new Date(baseTime).toISOString());
+
+      expect(result.messages[1].role).toBe("assistant");
+      expect(result.messages[1].content).toBe("Hello from assistant");
+      expect(result.messages[1].model).toBe("anthropic/claude-opus-4-6");
+    });
+
+    test("filters out system messages", async () => {
+      const db = createTestDb();
+      const baseTime = Date.now();
+
+      insertMessage(db, "msg0", "ses_abc", baseTime, { role: "system" });
+      insertPart(db, "part0", "msg0", { type: "text", text: "System prompt" });
+
+      insertMessage(db, "msg1", "ses_abc", baseTime + 1000, { role: "user" });
+      insertPart(db, "part1", "msg1", { type: "text", text: "User msg" });
+
+      insertMessage(db, "msg2", "ses_abc", baseTime + 2000, { role: "assistant" });
+      insertPart(db, "part2", "msg2", { type: "text", text: "Assistant msg" });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.total).toBe(2);
+      expect(result.messages).toHaveLength(2);
+    });
+
+    test("returns empty result for session with no messages", async () => {
+      const db = createTestDb();
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_empty", 0, 10);
+      expect(result.total).toBe(0);
+      expect(result.messages).toHaveLength(0);
+      expect(result.hasMore).toBe(false);
+    });
+
+    test("handles tool-invocation parts in SQLite", async () => {
+      const db = createTestDb();
+      const baseTime = Date.now();
+
+      insertMessage(db, "msg1", "ses_abc", baseTime, { role: "assistant" });
+      insertPart(db, "part1", "msg1", { type: "text", text: "Let me check." });
+      insertPart(db, "part2", "msg1", {
+        type: "tool-invocation",
+        name: "Read",
+        toolCallId: "tc_100",
+      });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.messages[0].content).toBe("Let me check.");
+      expect(result.messages[0].toolUse).toEqual([{ name: "Read", id: "tc_100" }]);
+    });
+
+    test("falls back to part.id when toolCallId is missing in SQLite", async () => {
+      const db = createTestDb();
+      insertMessage(db, "msg1", "ses_abc", Date.now(), { role: "assistant" });
+      insertPart(db, "part-fallback-id", "msg1", {
+        type: "tool-invocation",
+        name: "Bash",
+      });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.messages[0].toolUse).toEqual([{ name: "Bash", id: "part-fallback-id" }]);
+    });
+
+    test("omits toolUse when no tool parts exist in SQLite", async () => {
+      const db = createTestDb();
+      insertMessage(db, "msg1", "ses_abc", Date.now(), { role: "user" });
+      insertPart(db, "part1", "msg1", { type: "text", text: "Just a question" });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.messages[0].toolUse).toBeUndefined();
+    });
+
+    test("joins multiple text parts with double newline in SQLite", async () => {
+      const db = createTestDb();
+      insertMessage(db, "msg1", "ses_abc", Date.now(), { role: "assistant" });
+      insertPart(db, "part1", "msg1", { type: "text", text: "Paragraph one." });
+      insertPart(db, "part2", "msg1", { type: "text", text: "Paragraph two." });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.messages[0].content).toBe("Paragraph one.\n\nParagraph two.");
+    });
+
+    test("formats model as providerID/modelID when both present", async () => {
+      const db = createTestDb();
+      insertMessage(db, "msg1", "ses_abc", Date.now(), {
+        role: "assistant",
+        modelID: "gpt-4o",
+        providerID: "openai",
+      });
+      insertPart(db, "part1", "msg1", { type: "text", text: "Hi" });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.messages[0].model).toBe("openai/gpt-4o");
+    });
+
+    test("strips leading slash when providerID is empty", async () => {
+      const db = createTestDb();
+      insertMessage(db, "msg1", "ses_abc", Date.now(), {
+        role: "assistant",
+        modelID: "gpt-4o",
+      });
+      insertPart(db, "part1", "msg1", { type: "text", text: "Hi" });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      // model = "/gpt-4o" -> stripped to "gpt-4o"
+      expect(result.messages[0].model).toBe("gpt-4o");
+    });
+
+    test("sets model to undefined when modelID is missing", async () => {
+      const db = createTestDb();
+      insertMessage(db, "msg1", "ses_abc", Date.now(), { role: "assistant" });
+      insertPart(db, "part1", "msg1", { type: "text", text: "Hi" });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.messages[0].model).toBeUndefined();
+    });
+
+    test("defaults role to user when data JSON is malformed", async () => {
+      const db = createTestDb();
+      insertMessage(db, "msg1", "ses_abc", Date.now(), { role: "user" });
+      insertPart(db, "part1", "msg1", { type: "text", text: "Hello" });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.messages[0].role).toBe("user");
+    });
+
+    test("skips parts with unparseable JSON data", async () => {
+      const db = createTestDb();
+      insertMessage(db, "msg1", "ses_abc", Date.now(), { role: "assistant" });
+      // Insert a part with valid JSON
+      insertPart(db, "part1", "msg1", { type: "text", text: "Good part" });
+      // Insert a part with invalid JSON directly
+      db.run("INSERT INTO part (id, message_id, data) VALUES (?, ?, ?)", ["part2", "msg1", "not valid json"]);
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.messages[0].content).toBe("Good part");
+    });
+
+    test("handles messages with no parts", async () => {
+      const db = createTestDb();
+      insertMessage(db, "msg1", "ses_abc", Date.now(), { role: "user" });
+      // No parts inserted for this message
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.messages[0].content).toBe("");
+      expect(result.messages[0].toolUse).toBeUndefined();
+    });
+
+    test("paginates from end correctly with SQLite", async () => {
+      const db = createTestDb();
+      const baseTime = Date.now();
+
+      for (let i = 0; i < 5; i++) {
+        const role = i % 2 === 0 ? "user" : "assistant";
+        insertMessage(db, `msg${i}`, "ses_abc", baseTime + i * 1000, { role });
+        insertPart(db, `part${i}`, `msg${i}`, { type: "text", text: `Message ${i}` });
+      }
+      db.close();
+
+      // Get last 2 messages (offset=0, limit=2)
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 2);
+      expect(result.total).toBe(5);
+      expect(result.messages).toHaveLength(2);
+      expect(result.hasMore).toBe(true);
+      expect(result.messages[0].content).toBe("Message 3");
+      expect(result.messages[1].content).toBe("Message 4");
+    });
+
+    test("paginates with offset to get earlier messages in SQLite", async () => {
+      const db = createTestDb();
+      const baseTime = Date.now();
+
+      for (let i = 0; i < 5; i++) {
+        const role = i % 2 === 0 ? "user" : "assistant";
+        insertMessage(db, `msg${i}`, "ses_abc", baseTime + i * 1000, { role });
+        insertPart(db, `part${i}`, `msg${i}`, { type: "text", text: `Message ${i}` });
+      }
+      db.close();
+
+      // Skip last 2, get 2 more (offset=2, limit=2)
+      const result = await getOpenCodeSessionMessages("ses_abc", 2, 2);
+      expect(result.total).toBe(5);
+      expect(result.messages).toHaveLength(2);
+      expect(result.hasMore).toBe(true);
+      expect(result.messages[0].content).toBe("Message 1");
+      expect(result.messages[1].content).toBe("Message 2");
+    });
+
+    test("hasMore is false when retrieving from the beginning", async () => {
+      const db = createTestDb();
+      const baseTime = Date.now();
+
+      for (let i = 0; i < 3; i++) {
+        const role = i % 2 === 0 ? "user" : "assistant";
+        insertMessage(db, `msg${i}`, "ses_abc", baseTime + i * 1000, { role });
+        insertPart(db, `part${i}`, `msg${i}`, { type: "text", text: `Message ${i}` });
+      }
+      db.close();
+
+      // Get all messages (offset=0, limit=100)
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 100);
+      expect(result.total).toBe(3);
+      expect(result.messages).toHaveLength(3);
+      expect(result.hasMore).toBe(false);
+    });
+
+    test("isolates messages by session ID", async () => {
+      const db = createTestDb();
+      const baseTime = Date.now();
+
+      insertMessage(db, "msg1", "ses_abc", baseTime, { role: "user" });
+      insertPart(db, "part1", "msg1", { type: "text", text: "Session A" });
+
+      insertMessage(db, "msg2", "ses_xyz", baseTime + 1000, { role: "user" });
+      insertPart(db, "part2", "msg2", { type: "text", text: "Session B" });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.total).toBe(1);
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].content).toBe("Session A");
+    });
+
+    test("throws 'Session not found' when database does not exist", async () => {
+      // Re-mock with a non-existent path
+      mock.module(SESSION_DISCOVERY_PATH, () => ({
+        OPENCODE_DB_PATH: join(tempDir, "nonexistent.db"),
+      }));
+
+      await expect(getOpenCodeSessionMessages("ses_missing", 0, 10)).rejects.toThrow("Session not found");
+    });
+
+    test("handles multiple tool invocations in a single message", async () => {
+      const db = createTestDb();
+      insertMessage(db, "msg1", "ses_abc", Date.now(), { role: "assistant" });
+      insertPart(db, "part1", "msg1", { type: "text", text: "Running commands." });
+      insertPart(db, "part2", "msg1", { type: "tool-invocation", name: "Read", toolCallId: "tc1" });
+      insertPart(db, "part3", "msg1", { type: "tool-invocation", name: "Edit", toolCallId: "tc2" });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.messages[0].toolUse).toHaveLength(2);
+      expect(result.messages[0].toolUse).toEqual([
+        { name: "Read", id: "tc1" },
+        { name: "Edit", id: "tc2" },
+      ]);
+    });
+  });
+});

--- a/agent/src/providers/opencode/process-mapper.test.ts
+++ b/agent/src/providers/opencode/process-mapper.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractOpenCodeSessionIdFromArgs } from "./process-mapper";
+
+describe("extractOpenCodeSessionIdFromArgs", () => {
+  describe("with --session flag", () => {
+    test("extracts session ID after --session", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode --session ses_abc123")).toBe("ses_abc123");
+    });
+
+    test("extracts session ID when --session is at the end of args", () => {
+      expect(extractOpenCodeSessionIdFromArgs("--session ses_end")).toBe("ses_end");
+    });
+
+    test("extracts session ID with full binary path", () => {
+      expect(extractOpenCodeSessionIdFromArgs("/usr/local/bin/opencode --session ses_xyz789")).toBe("ses_xyz789");
+    });
+
+    test("extracts session ID when other flags precede --session", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode --model gpt-4 --session ses_after")).toBe("ses_after");
+    });
+
+    test("extracts session ID when other flags follow --session", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode --session ses_before --model anthropic/claude-opus-4-6")).toBe(
+        "ses_before",
+      );
+    });
+
+    test("extracts session ID with multiple spaces between flag and value", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode --session   ses_spaces")).toBe("ses_spaces");
+    });
+  });
+
+  describe("with -s flag", () => {
+    test("extracts session ID after -s", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode -s ses_short")).toBe("ses_short");
+    });
+
+    test("extracts session ID from -s with full binary path", () => {
+      expect(extractOpenCodeSessionIdFromArgs("/home/user/.local/bin/opencode -s ses_path")).toBe("ses_path");
+    });
+
+    test("extracts session ID from -s when other flags are present", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode --model gpt-4 -s ses_mixed")).toBe("ses_mixed");
+    });
+
+    test("extracts session ID from -s with multiple spaces", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode -s    ses_multi")).toBe("ses_multi");
+    });
+  });
+
+  describe("returns undefined for missing session flag", () => {
+    test("returns undefined for bare opencode command", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode")).toBeUndefined();
+    });
+
+    test("returns undefined when no session flag is present", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode --model gpt-4 --verbose")).toBeUndefined();
+    });
+
+    test("returns undefined for empty string", () => {
+      expect(extractOpenCodeSessionIdFromArgs("")).toBeUndefined();
+    });
+
+    test("returns undefined for unrelated command with session-like text", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode --sessions ses_abc123")).toBeUndefined();
+    });
+
+    test("returns undefined when flag is missing value", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode --session")).toBeUndefined();
+    });
+
+    test("returns undefined when -s flag is missing value", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode -s")).toBeUndefined();
+    });
+  });
+
+  describe("edge cases", () => {
+    test("handles session ID with underscores and alphanumeric chars", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode --session ses_30163a6c1ffeYDGuDOrp0nH9vG")).toBe(
+        "ses_30163a6c1ffeYDGuDOrp0nH9vG",
+      );
+    });
+
+    test("handles session ID with hyphens", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode --session my-session-id")).toBe("my-session-id");
+    });
+
+    test("extracts only the first session ID when --session appears twice", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode --session ses_first --session ses_second")).toBe("ses_first");
+    });
+
+    test("does not match --session embedded in another flag name", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode --no-session ses_none")).toBeUndefined();
+    });
+
+    test("handles tab characters between flag and value", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode --session\tses_tab")).toBe("ses_tab");
+    });
+
+    test("does not confuse -session (single dash, long name) with valid flags", () => {
+      expect(extractOpenCodeSessionIdFromArgs("opencode -session ses_invalid")).toBeUndefined();
+    });
+  });
+});

--- a/agent/src/providers/utils.test.ts
+++ b/agent/src/providers/utils.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AgentProcess } from "./types";
+import { extractBinaryName, filterProcessesByBinary, isBinaryAvailable } from "./utils";
+
+/** Factory helper for AgentProcess test data. */
+function makeProcess(overrides: Partial<AgentProcess> & { args: string }): AgentProcess {
+  return {
+    pid: 1,
+    ppid: 0,
+    etimes: 100,
+    ...overrides,
+  };
+}
+
+describe("extractBinaryName", () => {
+  test("extracts binary from absolute path", () => {
+    expect(extractBinaryName("/usr/bin/claude --resume abc")).toBe("claude");
+  });
+
+  test("extracts binary from bare command without path", () => {
+    expect(extractBinaryName("opencode --session ses_abc")).toBe("opencode");
+  });
+
+  test("extracts binary from bare command without arguments", () => {
+    expect(extractBinaryName("claude")).toBe("claude");
+  });
+
+  test("extracts binary from deep nested path", () => {
+    expect(extractBinaryName("/home/user/.local/share/bin/node --inspect")).toBe("node");
+  });
+
+  test("extracts binary from path without arguments", () => {
+    expect(extractBinaryName("/usr/local/bin/bun")).toBe("bun");
+  });
+
+  test("returns undefined for empty string", () => {
+    expect(extractBinaryName("")).toBe("");
+  });
+
+  test("extracts binary when path ends with slash", () => {
+    // "/usr/bin/".split("/").pop() => "" => "".split(" ")[0] => ""
+    expect(extractBinaryName("/usr/bin/")).toBe("");
+  });
+
+  test("extracts binary with multiple spaces in arguments", () => {
+    expect(extractBinaryName("/usr/bin/claude  --flag  value")).toBe("claude");
+  });
+
+  test("handles single slash prefix", () => {
+    expect(extractBinaryName("/claude")).toBe("claude");
+  });
+
+  test("handles command starting with dot-slash", () => {
+    expect(extractBinaryName("./node_modules/.bin/biome check")).toBe("biome");
+  });
+});
+
+describe("filterProcessesByBinary", () => {
+  test("filters processes matching the given binary name", () => {
+    const processes = [
+      makeProcess({ pid: 1, args: "/usr/bin/claude --resume abc" }),
+      makeProcess({ pid: 2, args: "opencode --session ses_123" }),
+      makeProcess({ pid: 3, args: "claude" }),
+      makeProcess({ pid: 4, args: "/home/user/.local/bin/node" }),
+    ];
+    const result = filterProcessesByBinary(processes, "claude");
+    expect(result).toHaveLength(2);
+    expect(result[0].pid).toBe(1);
+    expect(result[1].pid).toBe(3);
+  });
+
+  test("returns empty array when no processes match", () => {
+    const processes = [
+      makeProcess({ pid: 1, args: "/usr/bin/node server.js" }),
+      makeProcess({ pid: 2, args: "bun run dev" }),
+    ];
+    const result = filterProcessesByBinary(processes, "claude");
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array when given empty array", () => {
+    const result = filterProcessesByBinary([], "claude");
+    expect(result).toEqual([]);
+  });
+
+  test("returns all processes when all match", () => {
+    const processes = [
+      makeProcess({ pid: 1, args: "/usr/bin/opencode --session ses_1" }),
+      makeProcess({ pid: 2, args: "opencode" }),
+      makeProcess({ pid: 3, args: "/opt/bin/opencode --model gpt-4" }),
+    ];
+    const result = filterProcessesByBinary(processes, "opencode");
+    expect(result).toHaveLength(3);
+  });
+
+  test("does not match partial binary names", () => {
+    const processes = [
+      makeProcess({ pid: 1, args: "/usr/bin/claude-dev --flag" }),
+      makeProcess({ pid: 2, args: "claude" }),
+    ];
+    const result = filterProcessesByBinary(processes, "claude");
+    expect(result).toHaveLength(1);
+    expect(result[0].pid).toBe(2);
+  });
+
+  test("preserves original process data in results", () => {
+    const processes = [makeProcess({ pid: 42, ppid: 10, etimes: 999, args: "claude --resume abc" })];
+    const result = filterProcessesByBinary(processes, "claude");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ pid: 42, ppid: 10, etimes: 999, args: "claude --resume abc" });
+  });
+});
+
+describe("isBinaryAvailable", () => {
+  // isBinaryAvailable spawns `which <binary>` and checks the exit code.
+  // We test it with a binary that is guaranteed to exist (sh) and one
+  // that almost certainly does not.
+
+  test("returns true for a binary that exists on the system", async () => {
+    const result = await isBinaryAvailable("sh");
+    expect(result).toBe(true);
+  });
+
+  test("returns false for a binary that does not exist", async () => {
+    const result = await isBinaryAvailable("__nonexistent_binary_agent_town_test__");
+    expect(result).toBe(false);
+  });
+
+  test("returns false for an empty string binary name", async () => {
+    const result = await isBinaryAvailable("");
+    expect(result).toBe(false);
+  });
+});

--- a/dashboard/src/utils.test.ts
+++ b/dashboard/src/utils.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from "bun:test";
+import { API, STATUS_CONFIG, shortenPath, timeAgo } from "./utils";
+
+describe("timeAgo", () => {
+  test("returns 'just now' for timestamps less than 10 seconds ago", () => {
+    const now = new Date().toISOString();
+    expect(timeAgo(now)).toBe("just now");
+  });
+
+  test("returns 'just now' for a timestamp 5 seconds ago", () => {
+    const fiveSecondsAgo = new Date(Date.now() - 5_000).toISOString();
+    expect(timeAgo(fiveSecondsAgo)).toBe("just now");
+  });
+
+  test("returns seconds ago for timestamps between 10 and 59 seconds", () => {
+    const thirtySecondsAgo = new Date(Date.now() - 30_000).toISOString();
+    expect(timeAgo(thirtySecondsAgo)).toBe("30s ago");
+  });
+
+  test("returns seconds ago at the 10-second boundary", () => {
+    const tenSecondsAgo = new Date(Date.now() - 10_000).toISOString();
+    expect(timeAgo(tenSecondsAgo)).toBe("10s ago");
+  });
+
+  test("returns seconds ago at the 59-second boundary", () => {
+    const fiftyNineSecondsAgo = new Date(Date.now() - 59_000).toISOString();
+    expect(timeAgo(fiftyNineSecondsAgo)).toBe("59s ago");
+  });
+
+  test("returns minutes ago for timestamps between 1 and 59 minutes", () => {
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60_000).toISOString();
+    expect(timeAgo(fiveMinutesAgo)).toBe("5m ago");
+  });
+
+  test("returns minutes ago at the 1-minute boundary", () => {
+    const oneMinuteAgo = new Date(Date.now() - 60_000).toISOString();
+    expect(timeAgo(oneMinuteAgo)).toBe("1m ago");
+  });
+
+  test("returns minutes ago at the 59-minute boundary", () => {
+    const fiftyNineMinutesAgo = new Date(Date.now() - 59 * 60_000).toISOString();
+    expect(timeAgo(fiftyNineMinutesAgo)).toBe("59m ago");
+  });
+
+  test("returns hours ago for timestamps 1 hour or more", () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60_000).toISOString();
+    expect(timeAgo(oneHourAgo)).toBe("1h ago");
+  });
+
+  test("returns hours ago for multi-hour timestamps", () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60_000).toISOString();
+    expect(timeAgo(threeHoursAgo)).toBe("3h ago");
+  });
+
+  test("returns large hour count for timestamps days ago", () => {
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60_000).toISOString();
+    expect(timeAgo(twoDaysAgo)).toBe("48h ago");
+  });
+
+  test("returns hours ago for a future timestamp (negative seconds floors to 0)", () => {
+    const futureTimestamp = new Date(Date.now() + 10 * 60_000).toISOString();
+    // Math.floor of a negative number goes further negative,
+    // so seconds < 10 is true => "just now"
+    expect(timeAgo(futureTimestamp)).toBe("just now");
+  });
+});
+
+describe("shortenPath", () => {
+  test("replaces /home/username with ~ for Linux paths", () => {
+    expect(shortenPath("/home/alice/projects/my-app")).toBe("~/projects/my-app");
+  });
+
+  test("replaces /home/username with ~ when path is exactly home dir", () => {
+    expect(shortenPath("/home/bob")).toBe("~");
+  });
+
+  test("replaces /home/username with ~ for deeply nested paths", () => {
+    expect(shortenPath("/home/carol/a/b/c/d/e")).toBe("~/a/b/c/d/e");
+  });
+
+  test("does not modify paths outside /home", () => {
+    expect(shortenPath("/var/log/syslog")).toBe("/var/log/syslog");
+  });
+
+  test("does not modify root path", () => {
+    expect(shortenPath("/")).toBe("/");
+  });
+
+  test("does not modify /tmp paths", () => {
+    expect(shortenPath("/tmp/some-file")).toBe("/tmp/some-file");
+  });
+
+  test("handles /home with no username gracefully", () => {
+    expect(shortenPath("/home")).toBe("/home");
+  });
+
+  test("handles /home/ with trailing slash but no username", () => {
+    expect(shortenPath("/home/")).toBe("/home/");
+  });
+
+  test("handles empty string", () => {
+    expect(shortenPath("")).toBe("");
+  });
+
+  test("handles relative paths without modification", () => {
+    expect(shortenPath("relative/path")).toBe("relative/path");
+  });
+
+  test("handles usernames with hyphens and underscores", () => {
+    expect(shortenPath("/home/my-user_name/work")).toBe("~/work");
+  });
+});
+
+describe("STATUS_CONFIG", () => {
+  const ALL_STATUSES = [
+    "starting",
+    "working",
+    "awaiting_input",
+    "action_required",
+    "idle",
+    "done",
+    "error",
+    "exited",
+  ] as const;
+
+  test("has an entry for every SessionStatus value", () => {
+    for (const status of ALL_STATUSES) {
+      expect(STATUS_CONFIG[status]).toBeDefined();
+    }
+  });
+
+  test("every entry has the required StatusStyle fields", () => {
+    for (const status of ALL_STATUSES) {
+      const style = STATUS_CONFIG[status];
+      expect(typeof style.label).toBe("string");
+      expect(typeof style.color).toBe("string");
+      expect(typeof style.bg).toBe("string");
+      expect(typeof style.pulse).toBe("boolean");
+    }
+  });
+
+  test("labels are human-readable and non-empty", () => {
+    for (const status of ALL_STATUSES) {
+      expect(STATUS_CONFIG[status].label.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("colors are valid hex color strings", () => {
+    const hexColorRegex = /^#[0-9a-fA-F]{6}$/;
+    for (const status of ALL_STATUSES) {
+      expect(STATUS_CONFIG[status].color).toMatch(hexColorRegex);
+      expect(STATUS_CONFIG[status].bg).toMatch(hexColorRegex);
+    }
+  });
+
+  test("active statuses pulse and inactive statuses do not", () => {
+    expect(STATUS_CONFIG.starting.pulse).toBe(true);
+    expect(STATUS_CONFIG.working.pulse).toBe(true);
+    expect(STATUS_CONFIG.action_required.pulse).toBe(true);
+    expect(STATUS_CONFIG.error.pulse).toBe(true);
+    expect(STATUS_CONFIG.exited.pulse).toBe(true);
+
+    expect(STATUS_CONFIG.awaiting_input.pulse).toBe(false);
+    expect(STATUS_CONFIG.idle.pulse).toBe(false);
+    expect(STATUS_CONFIG.done.pulse).toBe(false);
+  });
+
+  test("has correct labels for each status", () => {
+    expect(STATUS_CONFIG.starting.label).toBe("Starting");
+    expect(STATUS_CONFIG.working.label).toBe("Working");
+    expect(STATUS_CONFIG.awaiting_input.label).toBe("Awaiting Input");
+    expect(STATUS_CONFIG.action_required.label).toBe("Action Required");
+    expect(STATUS_CONFIG.idle.label).toBe("Idle");
+    expect(STATUS_CONFIG.done.label).toBe("Done");
+    expect(STATUS_CONFIG.error.label).toBe("Error");
+    expect(STATUS_CONFIG.exited.label).toBe("Exited");
+  });
+});
+
+describe("API", () => {
+  test("SETTINGS endpoint is correct", () => {
+    expect(API.SETTINGS).toBe("/api/settings");
+  });
+
+  test("MACHINES endpoint is correct", () => {
+    expect(API.MACHINES).toBe("/api/machines");
+  });
+
+  test("SESSION_MESSAGES endpoint is correct", () => {
+    expect(API.SESSION_MESSAGES).toBe("/api/session-messages");
+  });
+
+  test("SESSIONS_RENAME endpoint is correct", () => {
+    expect(API.SESSIONS_RENAME).toBe("/api/sessions/rename");
+  });
+
+  test("SESSIONS_KILL endpoint is correct", () => {
+    expect(API.SESSIONS_KILL).toBe("/api/sessions/kill");
+  });
+
+  test("SESSIONS_DELETE endpoint is correct", () => {
+    expect(API.SESSIONS_DELETE).toBe("/api/sessions/delete");
+  });
+
+  test("SESSIONS_SEND endpoint is correct", () => {
+    expect(API.SESSIONS_SEND).toBe("/api/sessions/send");
+  });
+
+  test("AGENTS_LAUNCH endpoint is correct", () => {
+    expect(API.AGENTS_LAUNCH).toBe("/api/agents/launch");
+  });
+
+  test("AGENTS_RESUME endpoint is correct", () => {
+    expect(API.AGENTS_RESUME).toBe("/api/agents/resume");
+  });
+
+  test("SESSIONS_RECONNECT endpoint is correct", () => {
+    expect(API.SESSIONS_RECONNECT).toBe("/api/sessions/reconnect");
+  });
+
+  test("NODES endpoint is correct", () => {
+    expect(API.NODES).toBe("/api/nodes");
+  });
+
+  test("NODES_TEST endpoint is correct", () => {
+    expect(API.NODES_TEST).toBe("/api/nodes/test");
+  });
+
+  test("all endpoints start with /api/", () => {
+    for (const value of Object.values(API)) {
+      expect(value).toMatch(/^\/api\//);
+    }
+  });
+
+  test("contains exactly 12 endpoints", () => {
+    expect(Object.keys(API)).toHaveLength(12);
+  });
+});


### PR DESCRIPTION
## Summary

- Add 292 new tests across 9 previously untested modules
- Test count: 179 → 471 (163% increase)
- Test files: 14 → 23

### New test files

| File | Tests | Coverage |
|------|-------|----------|
| `claude-code/hook-handler.test.ts` | 38 | All hook event types, invalid payloads, status mappings |
| `claude-code/process-mapper.test.ts` | 29 | Session ID extraction, birth time matching |
| `claude-code/message-parser.test.ts` | 32 | JSONL parsing, formatting, pagination, tool use |
| `claude-code/session-discovery.test.ts` | 37 | Session parsing, status detection, retention filtering |
| `opencode/process-mapper.test.ts` | 22 | Session ID extraction from args |
| `opencode/event-handler.test.ts` | 35 | SSE event mapping, webhook handling |
| `opencode/message-parser.test.ts` | 37 | SDK + SQLite dual-path, pagination |
| `providers/utils.test.ts` | 19 | Binary detection, process filtering |
| `dashboard/src/utils.test.ts` | 43 | timeAgo, shortenPath, STATUS_CONFIG, API constants |

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)