### PR TITLE
feat: enhanced message history with tool call grouping and toggle

### DIFF
--- a/agent/src/providers/claude-code/message-parser.test.ts
+++ b/agent/src/providers/claude-code/message-parser.test.ts
@@ -284,6 +284,202 @@ describe("formatClaudeEntry", () => {
     expect(result.toolResult).toHaveLength(500);
     expect(result.toolResult).toBe(exactContent);
   });
+
+  // --- Thinking block tests ---
+
+  test("extracts a single thinking block", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Let me analyze this problem step by step." },
+          { type: "text", text: "Here is my answer." },
+        ],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.thinking).toBe("Let me analyze this problem step by step.");
+    expect(result.content).toBe("Here is my answer.");
+  });
+
+  test("joins multiple thinking blocks with double newline", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "First thought." },
+          { type: "thinking", thinking: "Second thought." },
+          { type: "text", text: "Final answer." },
+        ],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.thinking).toBe("First thought.\n\nSecond thought.");
+    expect(result.content).toBe("Final answer.");
+  });
+
+  test("thinking is undefined when no thinking blocks exist", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "No thinking here." }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.thinking).toBeUndefined();
+  });
+
+  test("skips thinking blocks with non-string thinking property", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: 42 },
+          { type: "text", text: "Result." },
+        ],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.thinking).toBeUndefined();
+  });
+
+  // --- Tool input extraction tests ---
+
+  test("extracts tool_use input as JSON string", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            name: "Read",
+            id: "tool_1",
+            input: { file_path: "/home/user/file.ts" },
+          },
+        ],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolUse).toHaveLength(1);
+    expect(result.toolUse?.[0].input).toBeDefined();
+    const parsed = JSON.parse(result.toolUse![0].input!);
+    expect(parsed.file_path).toBe("/home/user/file.ts");
+  });
+
+  test("truncates tool_use input to 2000 characters", () => {
+    const longInput = { data: "x".repeat(3000) };
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", name: "Bash", id: "tool_2", input: longInput }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolUse?.[0].input).toBeDefined();
+    expect(result.toolUse![0].input!.length).toBeLessThanOrEqual(2000);
+  });
+
+  test("tool_use input is undefined when input is not provided", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", name: "Read", id: "tool_3" }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolUse?.[0].input).toBeUndefined();
+  });
+
+  // --- Multiple tool results tests ---
+
+  test("collects multiple tool_result blocks into toolResults array", () => {
+    const entry = makeEntry({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "tool_1", content: "Result one" },
+          { type: "tool_result", tool_use_id: "tool_2", content: "Result two" },
+        ],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolResults).toHaveLength(2);
+    expect(result.toolResults?.[0]).toEqual({ toolUseId: "tool_1", content: "Result one" });
+    expect(result.toolResults?.[1]).toEqual({ toolUseId: "tool_2", content: "Result two" });
+  });
+
+  test("handles tool_result with array content (text blocks inside)", () => {
+    const entry = makeEntry({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool_5",
+            content: [
+              { type: "text", text: "Line one" },
+              { type: "text", text: "Line two" },
+            ],
+          },
+        ],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolResults).toHaveLength(1);
+    expect(result.toolResults?.[0].content).toBe("Line one\nLine two");
+    expect(result.toolResults?.[0].toolUseId).toBe("tool_5");
+  });
+
+  test("truncates tool_result content to 2000 characters in toolResults", () => {
+    const longContent = "z".repeat(3000);
+    const entry = makeEntry({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "tool_6", content: longContent }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolResults?.[0].content.length).toBeLessThanOrEqual(2000);
+  });
+
+  test("toolResults is undefined when no tool_result blocks exist", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "No tools." }],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.toolResults).toBeUndefined();
+  });
+
+  // --- Mixed content tests ---
+
+  test("handles message with text, thinking, tool calls, and tool results", () => {
+    const entry = makeEntry({
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "I need to read the file." },
+          { type: "text", text: "Let me check that file." },
+          { type: "tool_use", name: "Read", id: "tool_r1", input: { path: "/tmp/test.ts" } },
+          { type: "tool_result", tool_use_id: "tool_r1", content: "file contents" },
+        ],
+      },
+    });
+    const result = formatClaudeEntry(entry);
+    expect(result.thinking).toBe("I need to read the file.");
+    expect(result.content).toBe("Let me check that file.");
+    expect(result.toolUse).toHaveLength(1);
+    expect(result.toolUse?.[0].name).toBe("Read");
+    expect(result.toolUse?.[0].input).toBeDefined();
+    expect(result.toolResults).toHaveLength(1);
+    expect(result.toolResults?.[0].toolUseId).toBe("tool_r1");
+    expect(result.toolResult).toBe("file contents");
+  });
 });
 
 describe("getClaudeSessionMessages", () => {

--- a/agent/src/providers/claude-code/message-parser.ts
+++ b/agent/src/providers/claude-code/message-parser.ts
@@ -22,31 +22,48 @@ export interface ClaudeMessageEntry {
   };
 }
 
+const TOOL_CONTENT_MAX_LENGTH = 2000;
+
 export function formatClaudeEntry(entry: ClaudeMessageEntry): SessionMessage {
   const content = entry.message?.content;
   let textContent = "";
-  let toolUse: { name: string; id: string }[] | undefined;
+  let toolUse: { name: string; id: string; input?: string }[] | undefined;
   let toolResult: string | undefined;
+  let toolResults: { toolUseId: string; content: string }[] | undefined;
+  let thinking: string | undefined;
 
   if (typeof content === "string") {
     textContent = content;
   } else if (Array.isArray(content)) {
     const textParts: string[] = [];
-    const tools: { name: string; id: string }[] = [];
+    const tools: { name: string; id: string; input?: string }[] = [];
+    const thinkingParts: string[] = [];
+    const results: { toolUseId: string; content: string }[] = [];
 
     for (const block of content) {
       const b = block as Record<string, unknown>;
       if (b.type === "text" && typeof b.text === "string") {
         textParts.push(b.text);
+      } else if (b.type === "thinking" && typeof b.thinking === "string") {
+        thinkingParts.push(b.thinking);
       } else if (b.type === "tool_use" && typeof b.name === "string" && typeof b.id === "string") {
-        tools.push({ name: b.name, id: b.id });
+        const input = b.input ? JSON.stringify(b.input, null, 2).slice(0, TOOL_CONTENT_MAX_LENGTH) : undefined;
+        tools.push({ name: b.name, id: b.id, input });
       } else if (b.type === "tool_result") {
-        toolResult = typeof b.content === "string" ? b.content.slice(0, 500) : "[tool output]";
+        const resultContent = extractToolResultContent(b);
+        const toolUseId = (b.tool_use_id || b.id || "") as string;
+        results.push({ toolUseId, content: resultContent });
+        // Keep legacy single toolResult for backward compat
+        if (!toolResult) {
+          toolResult = typeof b.content === "string" ? b.content.slice(0, 500) : "[tool output]";
+        }
       }
     }
 
     textContent = textParts.join("\n\n");
     if (tools.length > 0) toolUse = tools;
+    if (thinkingParts.length > 0) thinking = thinkingParts.join("\n\n");
+    if (results.length > 0) toolResults = results;
   }
 
   return {
@@ -55,8 +72,24 @@ export function formatClaudeEntry(entry: ClaudeMessageEntry): SessionMessage {
     content: textContent,
     toolUse,
     toolResult,
+    toolResults,
+    thinking,
     model: entry.message?.model,
   };
+}
+
+function extractToolResultContent(b: Record<string, unknown>): string {
+  if (typeof b.content === "string") {
+    return b.content.slice(0, TOOL_CONTENT_MAX_LENGTH);
+  }
+  if (Array.isArray(b.content)) {
+    return (b.content as Array<Record<string, unknown>>)
+      .filter((c) => c.type === "text" && typeof c.text === "string")
+      .map((c) => c.text as string)
+      .join("\n")
+      .slice(0, TOOL_CONTENT_MAX_LENGTH);
+  }
+  return "[tool output]";
 }
 
 export async function getClaudeSessionMessages(

--- a/agent/src/providers/opencode/message-parser.test.ts
+++ b/agent/src/providers/opencode/message-parser.test.ts
@@ -837,5 +837,144 @@ describe("getOpenCodeSessionMessages", () => {
         { name: "Edit", id: "tc2" },
       ]);
     });
+
+    test("extracts tool-invocation input args in SQLite", async () => {
+      const db = createTestDb();
+      insertMessage(db, "msg1", "ses_abc", Date.now(), { role: "assistant" });
+      insertPart(db, "part1", "msg1", {
+        type: "tool-invocation",
+        name: "Read",
+        toolCallId: "tc1",
+        args: { file_path: "/home/user/test.ts" },
+      });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.messages[0].toolUse?.[0].input).toBeDefined();
+      const parsed = JSON.parse(result.messages[0].toolUse![0].input!);
+      expect(parsed.file_path).toBe("/home/user/test.ts");
+    });
+
+    test("extracts tool-invocation result in SQLite into toolResults", async () => {
+      const db = createTestDb();
+      insertMessage(db, "msg1", "ses_abc", Date.now(), { role: "assistant" });
+      insertPart(db, "part1", "msg1", {
+        type: "tool-invocation",
+        name: "Read",
+        toolCallId: "tc1",
+        state: "completed",
+        result: "file contents here",
+      });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.messages[0].toolResults).toHaveLength(1);
+      expect(result.messages[0].toolResults?.[0]).toEqual({
+        toolUseId: "tc1",
+        content: "file contents here",
+      });
+    });
+
+    test("toolResults is undefined when no tool results exist in SQLite", async () => {
+      const db = createTestDb();
+      insertMessage(db, "msg1", "ses_abc", Date.now(), { role: "assistant" });
+      insertPart(db, "part1", "msg1", { type: "text", text: "Just text." });
+      db.close();
+
+      const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
+      expect(result.messages[0].toolResults).toBeUndefined();
+    });
+  });
+
+  // =====================
+  // SDK tool results tests
+  // =====================
+
+  describe("SDK tool result extraction", () => {
+    test("extracts tool-invocation input args via SDK", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+          },
+          parts: [
+            {
+              id: "p1",
+              type: "tool-invocation",
+              name: "Read",
+              toolCallId: "tc_001",
+              args: { file_path: "/tmp/test.ts" },
+            } as SdkPart & { args: Record<string, unknown> },
+          ],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.messages[0].toolUse?.[0].input).toBeDefined();
+      const parsed = JSON.parse(result.messages[0].toolUse![0].input!);
+      expect(parsed.file_path).toBe("/tmp/test.ts");
+    });
+
+    test("extracts tool-invocation result via SDK into toolResults", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+          },
+          parts: [
+            {
+              id: "p1",
+              type: "tool-invocation",
+              name: "Read",
+              toolCallId: "tc_001",
+              state: "completed",
+              result: "the file contents",
+            } as SdkPart & { state: string; result: string },
+          ],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.messages[0].toolResults).toHaveLength(1);
+      expect(result.messages[0].toolResults?.[0]).toEqual({
+        toolUseId: "tc_001",
+        content: "the file contents",
+      });
+    });
+
+    test("toolResults is undefined when no tool results exist via SDK", async () => {
+      const sdkMessages: SdkMessage[] = [
+        makeSdkMessage({
+          info: {
+            role: "assistant",
+            time: { created: "2026-03-19T10:00:00.000Z" },
+          },
+          parts: [{ id: "p1", type: "text", text: "No tools here." }],
+        }),
+      ];
+
+      mockClient = {
+        session: {
+          messages: mock(() => Promise.resolve({ data: sdkMessages })),
+        },
+      };
+
+      const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
+      expect(result.messages[0].toolResults).toBeUndefined();
+    });
   });
 });

--- a/agent/src/providers/opencode/message-parser.ts
+++ b/agent/src/providers/opencode/message-parser.ts
@@ -51,7 +51,8 @@ async function getMessagesViaSDK(
 
   const messages: SessionMessage[] = slice.map((m) => {
     const textParts: string[] = [];
-    const toolUse: { name: string; id: string }[] = [];
+    const toolUse: { name: string; id: string; input?: string }[] = [];
+    const toolResults: { toolUseId: string; content: string }[] = [];
 
     for (const part of m.parts) {
       if (part.type === "text" && part.text) {
@@ -59,7 +60,12 @@ async function getMessagesViaSDK(
       } else if (part.type === "tool-invocation" || (part as Record<string, unknown>).type === "tool") {
         const p = part as Record<string, unknown>;
         const name = (p.name || p.toolName || "unknown") as string;
-        toolUse.push({ name, id: (p.toolCallId || part.id) as string });
+        const id = (p.toolCallId || part.id) as string;
+        const input = p.args ? JSON.stringify(p.args, null, 2).slice(0, 2000) : undefined;
+        toolUse.push({ name, id, input });
+        if (typeof p.result === "string") {
+          toolResults.push({ toolUseId: id, content: (p.result as string).slice(0, 2000) });
+        }
       }
     }
 
@@ -73,6 +79,7 @@ async function getMessagesViaSDK(
       timestamp: new Date(m.info.time.created).toISOString(),
       content: textParts.join("\n\n"),
       toolUse: toolUse.length > 0 ? toolUse : undefined,
+      toolResults: toolResults.length > 0 ? toolResults : undefined,
       model,
     };
   });
@@ -159,16 +166,30 @@ async function getMessagesViaSQLite(
       const role = (msgData?.role || "user") as "user" | "assistant";
 
       const textParts: string[] = [];
-      const toolUse: { name: string; id: string }[] = [];
+      const toolUse: { name: string; id: string; input?: string }[] = [];
+      const toolResults: { toolUseId: string; content: string }[] = [];
 
       for (const part of parts) {
-        const partData = safeJsonParse<{ type: string; text?: string; name?: string; toolCallId?: string }>(part.data);
+        const partData = safeJsonParse<{
+          type: string;
+          text?: string;
+          name?: string;
+          toolCallId?: string;
+          args?: Record<string, unknown>;
+          result?: string;
+          state?: string;
+        }>(part.data);
         if (!partData) continue;
 
         if (partData.type === "text" && partData.text) {
           textParts.push(partData.text);
         } else if (partData.type === "tool-invocation" && partData.name) {
-          toolUse.push({ name: partData.name, id: partData.toolCallId || part.id });
+          const id = partData.toolCallId || part.id;
+          const input = partData.args ? JSON.stringify(partData.args, null, 2).slice(0, 2000) : undefined;
+          toolUse.push({ name: partData.name, id, input });
+          if (typeof partData.result === "string") {
+            toolResults.push({ toolUseId: id, content: partData.result.slice(0, 2000) });
+          }
         }
       }
 
@@ -179,6 +200,7 @@ async function getMessagesViaSQLite(
         timestamp: new Date(row.time_created).toISOString(),
         content: textParts.join("\n\n"),
         toolUse: toolUse.length > 0 ? toolUse : undefined,
+        toolResults: toolResults.length > 0 ? toolResults : undefined,
         model: model?.startsWith("/") ? model.slice(1) : model,
       };
     });

--- a/dashboard/src/components/SessionDetail.tsx
+++ b/dashboard/src/components/SessionDetail.tsx
@@ -7,6 +7,55 @@ import { SendMessage } from "./SendMessage";
 
 const BATCH_SIZE = 10;
 
+function isToolResultMessage(msg: SessionMessage): boolean {
+  return msg.role === "user" && !msg.content.trim() && !!(msg.toolResult || msg.toolResults?.length);
+}
+
+function isToolOnlyMessage(msg: SessionMessage): boolean {
+  return msg.role === "assistant" && !msg.content.trim() && !msg.thinking && !!msg.toolUse?.length;
+}
+
+function ToolCallBlock({
+  tool,
+  toolResults,
+}: {
+  tool: { name: string; id: string; input?: string };
+  toolResults?: { toolUseId: string; content: string }[];
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const result = toolResults?.find((r) => r.toolUseId === tool.id);
+
+  return (
+    <div className="tool-call-group">
+      <button
+        type="button"
+        className="tool-call-header"
+        onClick={() => setExpanded(!expanded)}
+        aria-label={`${expanded ? "Collapse" : "Expand"} ${tool.name} tool call`}
+      >
+        <span className="tool-badge">{tool.name}</span>
+        <span className="tool-call-chevron">{expanded ? "\u25BC" : "\u25B6"}</span>
+      </button>
+      {expanded && (
+        <div className="tool-call-detail">
+          {tool.input && (
+            <div className="tool-call-input">
+              <div className="tool-call-label">Input</div>
+              <pre>{tool.input}</pre>
+            </div>
+          )}
+          {result && (
+            <div className="tool-call-result">
+              <div className="tool-call-label">Result</div>
+              <pre>{result.content}</pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 const markdownComponents: Record<
   string,
   React.ComponentType<{ className?: string; children?: React.ReactNode; [key: string]: unknown }>
@@ -58,6 +107,7 @@ export function SessionDetail({
   const [offset, setOffset] = useState(0);
   const [flash, setFlash] = useState(false);
   const [, setTick] = useState(0);
+  const [showToolDetails, setShowToolDetails] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messageContainerRef = useRef<HTMLDivElement>(null);
@@ -264,42 +314,93 @@ export function SessionDetail({
       </div>
 
       <div className={`fullscreen-messages ${flash ? "flash" : ""}`} ref={messageContainerRef}>
-        {hasMore && (
-          <button type="button" className="load-previous-btn" onClick={loadPrevious} disabled={loadingHistory}>
-            {loadingHistory ? "Loading..." : "Load previous messages"}
-          </button>
-        )}
-
-        {history.map((msg) => (
-          <div
-            key={`${msg.timestamp}-${msg.role}-${msg.content?.slice(0, 20) ?? ""}`}
-            className={`chat-message chat-${msg.role}`}
+        <div className="chat-controls">
+          {hasMore && (
+            <button type="button" className="load-previous-btn" onClick={loadPrevious} disabled={loadingHistory}>
+              {loadingHistory ? "Loading..." : "Load previous messages"}
+            </button>
+          )}
+          <button
+            type="button"
+            className="tool-toggle-btn"
+            onClick={() => setShowToolDetails((prev) => !prev)}
+            aria-label={showToolDetails ? "Hide tool details" : "Show tool details"}
           >
-            <div className="chat-message-header">
-              <span className="chat-role">{msg.role === "user" ? "You" : "Assistant"}</span>
-              <span className="chat-timestamp">{new Date(msg.timestamp).toLocaleString()}</span>
-              {msg.model && <span className="chat-model">{msg.model}</span>}
+            {showToolDetails ? "Hide tool details" : "Show tool details"}
+          </button>
+        </div>
+
+        {history
+          .filter((msg) => showToolDetails || !isToolResultMessage(msg))
+          .map((msg) => (
+            <div
+              key={`${msg.timestamp}-${msg.role}-${msg.content?.slice(0, 20) ?? ""}`}
+              className={`chat-message chat-${msg.role}`}
+            >
+              <div className="chat-message-header">
+                <span className="chat-role">{msg.role === "user" ? "You" : "Assistant"}</span>
+                <span className="chat-timestamp">{new Date(msg.timestamp).toLocaleString()}</span>
+                {msg.model && <span className="chat-model">{msg.model}</span>}
+              </div>
+              <div className="chat-message-body">
+                {msg.thinking && (
+                  <details className="thinking-block">
+                    <summary>Thinking...</summary>
+                    <div className="thinking-content">{msg.thinking}</div>
+                  </details>
+                )}
+                {msg.role === "assistant" ? (
+                  <>
+                    {msg.content.trim() ? (
+                      <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                        {msg.content}
+                      </Markdown>
+                    ) : isToolOnlyMessage(msg) && !showToolDetails ? (
+                      <div className="chat-tools-summary">
+                        Used{" "}
+                        {msg.toolUse!.map((t) => (
+                          <span key={t.id} className="tool-badge">
+                            {t.name}
+                          </span>
+                        ))}
+                      </div>
+                    ) : msg.toolUse?.length && showToolDetails ? null : !msg.thinking ? (
+                      <span className="chat-empty-hint">[No text content]</span>
+                    ) : null}
+                    {msg.toolUse && msg.toolUse.length > 0 && showToolDetails && (
+                      <div className="chat-tool-calls">
+                        {msg.toolUse.map((t) => (
+                          <ToolCallBlock key={t.id} tool={t} toolResults={msg.toolResults} />
+                        ))}
+                      </div>
+                    )}
+                    {msg.toolUse && msg.toolUse.length > 0 && !showToolDetails && msg.content.trim() && (
+                      <div className="chat-tools">
+                        {msg.toolUse.map((t) => (
+                          <span key={t.id} className="tool-badge">
+                            {t.name}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <div className="chat-user-text">
+                    {msg.content.trim()
+                      ? msg.content
+                      : showToolDetails && msg.toolResults?.length
+                        ? msg.toolResults.map((tr) => (
+                            <div key={tr.toolUseId} className="tool-call-result">
+                              <div className="tool-call-label">Result ({tr.toolUseId})</div>
+                              <pre>{tr.content}</pre>
+                            </div>
+                          ))
+                        : msg.content || "[tool result]"}
+                  </div>
+                )}
+              </div>
             </div>
-            <div className="chat-message-body">
-              {msg.role === "assistant" ? (
-                <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
-                  {msg.content || "[No text content]"}
-                </Markdown>
-              ) : (
-                <div className="chat-user-text">{msg.content || "[tool result]"}</div>
-              )}
-              {msg.toolUse && msg.toolUse.length > 0 && (
-                <div className="chat-tools">
-                  {msg.toolUse.map((t) => (
-                    <span key={t.id} className="tool-badge">
-                      {t.name}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        ))}
+          ))}
 
         {history.length === 0 && !loadingHistory && (
           <div className="no-sessions" style={{ padding: "40px 0" }}>

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -1335,9 +1335,16 @@ body {
   font-family: "SF Mono", "Fira Code", monospace;
 }
 
+.chat-controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
 .load-previous-btn {
   display: block;
-  margin: 8px auto 16px;
   padding: 6px 16px;
   background: var(--bg-elevated);
   border: 1px solid var(--border);
@@ -1355,6 +1362,136 @@ body {
 .load-previous-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.tool-toggle-btn {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.75rem;
+}
+
+.tool-toggle-btn:hover {
+  color: var(--text);
+  border-color: #555;
+}
+
+.chat-controls .load-previous-btn {
+  margin: 0;
+}
+
+.chat-tools-summary {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-style: italic;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+
+.chat-empty-hint {
+  color: var(--text-muted);
+  font-style: italic;
+  font-size: 0.85rem;
+}
+
+.chat-tool-calls {
+  margin-top: 6px;
+}
+
+.tool-call-group {
+  margin: 6px 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.tool-call-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  background: var(--bg-elevated);
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.tool-call-header:hover {
+  filter: brightness(1.1);
+}
+
+.tool-call-chevron {
+  margin-left: auto;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.tool-call-detail {
+  padding: 8px 10px;
+  border-top: 1px solid var(--border);
+  font-size: 0.8rem;
+}
+
+.tool-call-input,
+.tool-call-result {
+  margin: 4px 0;
+}
+
+.tool-call-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+
+.tool-call-input pre,
+.tool-call-result pre {
+  margin: 0;
+  padding: 8px;
+  background: var(--bg);
+  border-radius: 4px;
+  overflow-x: auto;
+  font-size: 0.75rem;
+  max-height: 300px;
+  overflow-y: auto;
+  font-family: "SF Mono", "Fira Code", monospace;
+}
+
+.tool-call-result {
+  border-top: 1px dashed var(--border);
+  padding-top: 8px;
+}
+
+.thinking-block {
+  margin: 6px 0;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.thinking-block summary {
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.thinking-content {
+  padding: 8px;
+  margin-top: 4px;
+  background: var(--bg);
+  border-radius: 4px;
+  font-style: normal;
+  font-size: 0.8rem;
+  max-height: 400px;
+  overflow-y: auto;
+  white-space: pre-wrap;
 }
 
 .fullscreen-actions {
@@ -1862,6 +1999,31 @@ body {
 /* Load previous button */
 .app.theme-light .load-previous-btn:hover {
   background: #e2e8f0;
+}
+
+/* Tool toggle button */
+.app.theme-light .tool-toggle-btn {
+  border-color: var(--border);
+}
+
+.app.theme-light .tool-toggle-btn:hover {
+  background: #e5e5e5;
+  border-color: #ccc;
+}
+
+/* Tool call blocks */
+.app.theme-light .tool-call-header {
+  background: var(--bg-elevated);
+}
+
+.app.theme-light .tool-call-input pre,
+.app.theme-light .tool-call-result pre {
+  background: #f5f5f5;
+}
+
+/* Thinking block */
+.app.theme-light .thinking-content {
+  background: #f5f5f5;
 }
 
 /* Picker option hover */

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -111,8 +111,10 @@ export interface SessionMessage {
   role: "user" | "assistant";
   timestamp: string;
   content: string;
-  toolUse?: { name: string; id: string }[];
+  toolUse?: { name: string; id: string; input?: string }[];
   toolResult?: string;
+  toolResults?: { toolUseId: string; content: string }[];
+  thinking?: string;
   model?: string;
 }
 


### PR DESCRIPTION
## Summary
- Add thinking block extraction to Claude Code message parser
- Add tool input args and multiple tool results to SessionMessage type
- Add show/hide toggle for tool call details in chat history
- Hide pure tool-result user messages by default for cleaner view
- Show compact "Used X, Y, Z" summary for tool-only assistant messages
- Add expandable tool call blocks showing input args and results
- Add collapsible thinking block display with muted styling
- Replace misleading "[No text content]" and "[tool result]" placeholders
- Extract tool input/result from OpenCode SDK and SQLite paths

## Test plan
- [x] Unit tests for thinking block extraction (single and multiple)
- [x] Unit tests for tool input extraction with truncation
- [x] Unit tests for multiple tool results with IDs
- [x] Unit tests for mixed content (text + thinking + tools)
- [x] Unit tests for OpenCode SDK tool input/result extraction
- [x] Unit tests for OpenCode SQLite tool input/result extraction
- [x] All 489 existing + new tests pass
- [x] Biome lint/format clean
- [x] Dashboard builds without errors
- [x] Manual: verify toggle hides/shows tool details
- [x] Manual: verify tool-only messages show compact summary
- [x] Manual: verify expandable tool blocks
- [x] Manual: verify thinking blocks render

Closes #56

Generated with [Claude Code](https://claude.com/claude-code)