### PR TITLE
refactor: remove duplicated UsageFields type in session-discovery

### DIFF
--- a/agent/src/providers/claude-code/session-discovery.ts
+++ b/agent/src/providers/claude-code/session-discovery.ts
@@ -31,6 +31,8 @@ export interface ClaudeJsonlEntry {
   toolUseResult?: string;
 }
 
+type UsageFields = NonNullable<ClaudeJsonlEntry["message"]["usage"]>;
+
 function detectClaudeStatus(lastModifiedMs: number): SessionStatus {
   const age = Date.now() - lastModifiedMs;
 
@@ -110,12 +112,6 @@ async function parseClaudeSessionFromJsonl(jsonlPath: string, mtimeMs: number): 
     }
 
     // Aggregate token usage from all lines and find last context size
-    interface UsageFields {
-      input_tokens?: number;
-      output_tokens?: number;
-      cache_creation_input_tokens?: number;
-      cache_read_input_tokens?: number;
-    }
     let lastContextTokens = 0;
     for (const line of lines) {
       if (!line.trim()) continue;
@@ -127,9 +123,7 @@ async function parseClaudeSessionFromJsonl(jsonlPath: string, mtimeMs: number): 
           if (typeof usage.output_tokens === "number") totalOutputTokens += usage.output_tokens;
           // Context = all input tokens sent on this turn (uncached + cache creation + cache read)
           const ctx =
-            (usage.input_tokens ?? 0) +
-            (usage.cache_creation_input_tokens ?? 0) +
-            (usage.cache_read_input_tokens ?? 0);
+            (usage.input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0);
           if (ctx > 0) lastContextTokens = ctx;
         }
       } catch (_err) {

--- a/dashboard/src/components/SessionDetail.tsx
+++ b/dashboard/src/components/SessionDetail.tsx
@@ -458,9 +458,7 @@ export function SessionDetail({
                 <path d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 010-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1h-6a1 1 0 00-1 1v6.708A2.486 2.486 0 016.5 9h6V1.5z" />
               </svg>
             </span>
-            <span className="detail-value mono">
-              {formatCompactTokens(session.contextTokens)} context
-            </span>
+            <span className="detail-value mono">{formatCompactTokens(session.contextTokens)} context</span>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Removed the duplicate `UsageFields` interface that was defined inside `parseClaudeSessionFromJsonl` function
- Added a module-level `type UsageFields = NonNullable<ClaudeJsonlEntry["message"]["usage"]>` that derives the type from the existing `ClaudeJsonlEntry` interface, eliminating the duplication
- Includes minor Biome formatting fixes applied by `bunx biome check --write .`

Closes #73

## Test plan

- [x] `bun test --filter session-discovery` — all 41 tests pass
- [x] `bun test` — all 599 tests pass, zero regressions
- [x] `bunx biome check --write .` — no new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)