### PR TITLE
refactor: replace inline style + !important with CSS custom properties

### DIFF
--- a/dashboard/src/components/ExplorerLayout.tsx
+++ b/dashboard/src/components/ExplorerLayout.tsx
@@ -386,7 +386,7 @@ export function ExplorerLayout({
       <div className={`sidebar-backdrop${sidebarOpen ? " open" : ""}`} onClick={onSidebarClose} aria-hidden="true" />
       <div
         className={`explorer-sidebar${sidebarOpen ? " open" : ""}${!sidebarVisible && !isMobile ? " collapsed" : ""}`}
-        style={{ width: sidebarVisible || isMobile ? sidebarResize.size : undefined }}
+        style={{ "--panel-width": `${sidebarResize.size}px` } as React.CSSProperties}
       >
         {/* biome-ignore lint/a11y/useSemanticElements: sidebar navigation entry */}
         <div

--- a/dashboard/src/components/SessionDetail.tsx
+++ b/dashboard/src/components/SessionDetail.tsx
@@ -458,9 +458,7 @@ export function SessionDetail({
                 <path d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 010-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1h-6a1 1 0 00-1 1v6.708A2.486 2.486 0 016.5 9h6V1.5z" />
               </svg>
             </span>
-            <span className="detail-value mono">
-              {formatCompactTokens(session.contextTokens)} context
-            </span>
+            <span className="detail-value mono">{formatCompactTokens(session.contextTokens)} context</span>
           </div>
         )}
       </div>
@@ -673,7 +671,7 @@ export function SessionDetail({
         {isWide && (
           <div
             className={`info-pane${!infoPaneVisible ? " collapsed" : ""}`}
-            style={infoPaneVisible ? { width: infoPaneResize.size } : undefined}
+            style={{ "--panel-width": `${infoPaneResize.size}px` } as React.CSSProperties}
           >
             {infoPaneContent}
           </div>

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -1234,6 +1234,7 @@ body {
 
 /* Info pane (right sidebar) */
 .info-pane {
+  width: var(--panel-width, 300px);
   flex-shrink: 0;
   background: var(--bg);
   overflow-y: auto;
@@ -1242,7 +1243,7 @@ body {
 }
 
 .info-pane.collapsed {
-  width: 0 !important;
+  width: 0;
   overflow: hidden;
 }
 
@@ -1957,6 +1958,7 @@ body {
 }
 
 .explorer-sidebar {
+  width: var(--panel-width, 300px);
   overflow-y: auto;
   overflow-x: hidden;
   background: var(--bg);
@@ -1966,7 +1968,7 @@ body {
 }
 
 .explorer-sidebar.collapsed {
-  width: 0 !important;
+  width: 0;
   padding: 0;
   overflow: hidden;
 }
@@ -3178,7 +3180,7 @@ body {
     top: 0;
     left: 0;
     bottom: 0;
-    width: 85vw !important;
+    width: 85vw;
     max-width: 320px;
     min-width: 0;
     z-index: 901;


### PR DESCRIPTION
## Summary

- Replace inline `width` styles on the explorer sidebar and info pane with CSS custom properties (`--panel-width`), so collapsed and mobile states no longer need `!important` overrides
- Remove 3 of 4 `!important` declarations related to panel widths (`.info-pane.collapsed`, `.explorer-sidebar.collapsed`, mobile `.explorer-sidebar`)
- Keep `.resizing * { cursor: inherit !important; }` as it legitimately needs to override various element cursors during drag

## How it works

The inline style now sets `--panel-width` (a CSS custom property) instead of `width` directly. The CSS rules use `width: var(--panel-width, 300px)` as the base, while `.collapsed` and mobile rules simply set `width: 0` or `width: 85vw` — which naturally win via CSS specificity (higher specificity for `.collapsed`, cascade order for media query) without needing `!important`.

Closes #75

## Test plan

- [ ] Verify sidebar resizing works correctly on desktop
- [ ] Verify sidebar collapse/expand animation works
- [ ] Verify info pane resizing works correctly on desktop
- [ ] Verify info pane collapse/expand animation works
- [ ] Verify mobile sidebar opens as slide-in overlay at 85vw
- [ ] Verify all 599 existing tests pass (confirmed)
- [ ] Verify Biome check passes with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)