### PR TITLE
chore: clean up Biome lint warnings and fix CI format errors

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -214,9 +214,9 @@ function trackMultiplexerAssociations(sessions: SessionInfo[], multiplexerSessio
     // against unclaimed mux session names. Handles sessions that existed before
     // tracking was added, and sessions whose customName is only in session-names.json.
     const nameCandidates = [savedNames[session.sessionId], session.customName, session.slug].filter(Boolean);
-    const matchedName = nameCandidates.find((n) => unclaimedMuxLookup.has(n!));
-    if (matchedName && unclaimedMuxLookup.has(matchedName)) {
-      const muxType = unclaimedMuxLookup.get(matchedName)!;
+    const matchedName = nameCandidates.find((n) => n != null && unclaimedMuxLookup.has(n));
+    const muxType = matchedName ? unclaimedMuxLookup.get(matchedName) : undefined;
+    if (matchedName && muxType) {
       session.multiplexer = muxType;
       session.multiplexerSession = matchedName;
       session.status = "exited";

--- a/agent/src/providers/claude-code/index.ts
+++ b/agent/src/providers/claude-code/index.ts
@@ -1,12 +1,10 @@
-import { createLogger, type SessionInfo, type SessionMessagesResponse } from "@agent-town/shared";
+import type { SessionInfo, SessionMessagesResponse } from "@agent-town/shared";
 import type { AgentProcess, AgentProvider, HookEventResult, LaunchOptions, ResumeOptions } from "../types";
 import { filterProcessesByBinary, isBinaryAvailable } from "../utils";
 import { handleClaudeHookEvent } from "./hook-handler";
 import { getClaudeSessionMessages } from "./message-parser";
 import { extractClaudeSessionIdFromArgs, findSessionCandidates, matchSessionByBirthTime } from "./process-mapper";
 import { deleteClaudeSessionData, discoverClaudeSessions } from "./session-discovery";
-
-const log = createLogger("claude:provider");
 
 export class ClaudeCodeProvider implements AgentProvider {
   readonly type = "claude-code" as const;

--- a/agent/src/providers/claude-code/message-parser.test.ts
+++ b/agent/src/providers/claude-code/message-parser.test.ts
@@ -362,7 +362,7 @@ describe("formatClaudeEntry", () => {
     const result = formatClaudeEntry(entry);
     expect(result.toolUse).toHaveLength(1);
     expect(result.toolUse?.[0].input).toBeDefined();
-    const parsed = JSON.parse(result.toolUse![0].input!);
+    const parsed = JSON.parse(result.toolUse?.[0]?.input ?? "");
     expect(parsed.file_path).toBe("/home/user/file.ts");
   });
 
@@ -376,7 +376,7 @@ describe("formatClaudeEntry", () => {
     });
     const result = formatClaudeEntry(entry);
     expect(result.toolUse?.[0].input).toBeDefined();
-    expect(result.toolUse![0].input!.length).toBeLessThanOrEqual(2000);
+    expect(result.toolUse?.[0]?.input?.length).toBeLessThanOrEqual(2000);
   });
 
   test("tool_use input is undefined when input is not provided", () => {

--- a/agent/src/providers/claude-code/session-discovery.test.ts
+++ b/agent/src/providers/claude-code/session-discovery.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
 
 import {

--- a/agent/src/providers/claude-code/session-discovery.ts
+++ b/agent/src/providers/claude-code/session-discovery.ts
@@ -127,9 +127,7 @@ async function parseClaudeSessionFromJsonl(jsonlPath: string, mtimeMs: number): 
           if (typeof usage.output_tokens === "number") totalOutputTokens += usage.output_tokens;
           // Context = all input tokens sent on this turn (uncached + cache creation + cache read)
           const ctx =
-            (usage.input_tokens ?? 0) +
-            (usage.cache_creation_input_tokens ?? 0) +
-            (usage.cache_read_input_tokens ?? 0);
+            (usage.input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0);
           if (ctx > 0) lastContextTokens = ctx;
         }
       } catch (_err) {

--- a/agent/src/providers/opencode/message-parser.test.ts
+++ b/agent/src/providers/opencode/message-parser.test.ts
@@ -851,7 +851,7 @@ describe("getOpenCodeSessionMessages", () => {
 
       const result = await getOpenCodeSessionMessages("ses_abc", 0, 10);
       expect(result.messages[0].toolUse?.[0].input).toBeDefined();
-      const parsed = JSON.parse(result.messages[0].toolUse![0].input!);
+      const parsed = JSON.parse(result.messages[0].toolUse?.[0]?.input ?? "");
       expect(parsed.file_path).toBe("/home/user/test.ts");
     });
 
@@ -1003,7 +1003,7 @@ describe("getOpenCodeSessionMessages", () => {
 
       const result = await getOpenCodeSessionMessages("ses_test123", 0, 10);
       expect(result.messages[0].toolUse?.[0].input).toBeDefined();
-      const parsed = JSON.parse(result.messages[0].toolUse![0].input!);
+      const parsed = JSON.parse(result.messages[0].toolUse?.[0]?.input ?? "");
       expect(parsed.file_path).toBe("/tmp/test.ts");
     });
 

--- a/agent/src/terminal-server.ts
+++ b/agent/src/terminal-server.ts
@@ -247,7 +247,7 @@ export function resolveSessionName(name: string): string {
   const seen = new Set<string>();
   while (sessionRenameMap.has(resolved) && !seen.has(resolved)) {
     seen.add(resolved);
-    resolved = sessionRenameMap.get(resolved)!;
+    resolved = sessionRenameMap.get(resolved) ?? resolved;
   }
   return resolved;
 }
@@ -400,7 +400,7 @@ export function startTerminalServer(port: number, machineId: string): Server {
         }
 
         try {
-          const result = await fetchGitDiff(dir!);
+          const result = await fetchGitDiff(dir ?? "");
           return Response.json(result);
         } catch (err) {
           if (err instanceof GitDiffError) {

--- a/dashboard/src/components/MachineGroup.tsx
+++ b/dashboard/src/components/MachineGroup.tsx
@@ -79,7 +79,10 @@ export function buildGroups(sessions: SessionInfo[], groupMode: GroupMode): [str
       if (!statusGroups.has(session.status)) statusGroups.set(session.status, []);
       statusGroups.get(session.status)?.push(session);
     }
-    return STATUS_GROUP_ORDER.filter((s) => statusGroups.has(s)).map((s) => [STATUS_LABELS[s], statusGroups.get(s)!]);
+    return STATUS_GROUP_ORDER.filter((s) => statusGroups.has(s)).map((s) => [
+      STATUS_LABELS[s],
+      statusGroups.get(s) ?? [],
+    ]);
   }
 
   if (groupMode === "none") {

--- a/dashboard/src/components/SessionCard.tsx
+++ b/dashboard/src/components/SessionCard.tsx
@@ -86,7 +86,7 @@ export function SessionCard({
   function handleOpenTerminal(e: React.MouseEvent) {
     e.stopPropagation();
     if (hasTerminal) {
-      onOpenTerminal(session.multiplexerSession!, session.multiplexer!);
+      onOpenTerminal(session.multiplexerSession ?? "", session.multiplexer ?? "zellij");
     }
   }
 
@@ -327,8 +327,8 @@ export function SessionCard({
           {hasTerminal && (
             <SendMessage
               machineId={machineId}
-              multiplexer={session.multiplexer!}
-              session={session.multiplexerSession!}
+              multiplexer={session.multiplexer ?? "zellij"}
+              session={session.multiplexerSession ?? ""}
               agentType={session.agentType}
             />
           )}

--- a/dashboard/src/components/SessionDetail.tsx
+++ b/dashboard/src/components/SessionDetail.tsx
@@ -355,7 +355,7 @@ export function SessionDetail({
         <button
           type="button"
           className="action-btn terminal-btn"
-          onClick={() => onOpenTerminal(session.multiplexerSession!, session.multiplexer!)}
+          onClick={() => onOpenTerminal(session.multiplexerSession ?? "", session.multiplexer ?? "zellij")}
         >
           Open Terminal
         </button>
@@ -458,9 +458,7 @@ export function SessionDetail({
                 <path d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 010-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1h-6a1 1 0 00-1 1v6.708A2.486 2.486 0 016.5 9h6V1.5z" />
               </svg>
             </span>
-            <span className="detail-value mono">
-              {formatCompactTokens(session.contextTokens)} context
-            </span>
+            <span className="detail-value mono">{formatCompactTokens(session.contextTokens)} context</span>
           </div>
         )}
       </div>
@@ -584,7 +582,7 @@ export function SessionDetail({
                         ) : isToolOnlyMessage(msg) && !showToolDetails ? (
                           <div className="chat-tools-summary">
                             Used{" "}
-                            {msg.toolUse!.map((t) => (
+                            {msg.toolUse?.map((t) => (
                               <span key={t.id} className="tool-badge">
                                 {t.name}
                               </span>
@@ -651,8 +649,8 @@ export function SessionDetail({
               <div className="fullscreen-input" style={{ height: inputResize.size }}>
                 <SendMessage
                   machineId={machineId}
-                  multiplexer={session.multiplexer!}
-                  session={session.multiplexerSession!}
+                  multiplexer={session.multiplexer ?? "zellij"}
+                  session={session.multiplexerSession ?? ""}
                   agentType={session.agentType}
                   onSent={handleSent}
                 />

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -3,7 +3,11 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./styles.css";
 
-createRoot(document.getElementById("root")!).render(
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element not found");
+}
+createRoot(rootElement).render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/server/src/ssh-manager.ts
+++ b/server/src/ssh-manager.ts
@@ -223,7 +223,7 @@ with open(path, "w") as f:
 print("HOOKS: configured")
 `;
 
-  const proc = Bun.spawn(["ssh", ...sshOpts, sshTarget, "python3 -c " + JSON.stringify(script)], {
+  const proc = Bun.spawn(["ssh", ...sshOpts, sshTarget, `python3 -c ${JSON.stringify(script)}`], {
     stdout: "pipe",
     stderr: "pipe",
   });


### PR DESCRIPTION
## Summary

- Fixed 2 CI-blocking Biome **format errors** (auto-formatted `session-discovery.ts` and `MachineGroup.tsx`)
- Resolved all 26 Biome **lint warnings** across 12 files:
  - Removed unused import (`homedir`) and unused variable (`const log` + its `createLogger` import)
  - Replaced all 22 non-null assertions (`!`) with proper null handling — optional chaining (`?.`), nullish coalescing (`??`), and explicit null guards
  - Converted string concatenation to template literal in `ssh-manager.ts`
- Biome check now passes with **0 errors and 0 warnings**
- All **599 tests pass** with no regressions

Closes #68
Closes #77

## Test plan

- [x] `bunx biome check .` — 0 errors, 0 warnings
- [x] `bun test` — 599 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)