### PR TITLE
feat(dashboard): add setting to control terminal fullscreen on new session launch

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -133,6 +133,7 @@ export function App(): React.JSX.Element {
   const [sortMode, setSortMode] = useState<SortMode>("recent");
   const [timeFilter, setTimeFilter] = useState<TimeFilter>("24h");
   const [autoDeleteOnClose, setAutoDeleteOnClose] = useState(false);
+  const [openTerminalFullscreen, setOpenTerminalFullscreen] = useState(true);
   const [theme, setTheme] = useState<"dark" | "light">(() => loadLocalStorage(STORAGE_KEYS.THEME, "dark"));
   const [fontSize, setFontSize] = useState<"small" | "medium" | "large">(() =>
     loadLocalStorage(STORAGE_KEYS.FONT_SIZE, "small"),
@@ -172,6 +173,7 @@ export function App(): React.JSX.Element {
       .then((r) => r.json())
       .then((s: Settings) => {
         setAutoDeleteOnClose(s.autoDeleteOnClose);
+        setOpenTerminalFullscreen(s.openTerminalFullscreen);
         setTheme(s.theme);
         setFontSize(s.fontSize);
         setEnableKeyboardNav(s.enableKeyboardNavigation);
@@ -686,7 +688,13 @@ export function App(): React.JSX.Element {
           setLaunchMachineId(undefined);
         }}
         machines={machines}
-        onLaunched={(machineId, sessionName, multiplexer) => handleOpenTerminal(machineId, sessionName, multiplexer)}
+        onLaunched={(machineId, sessionName, multiplexer) => {
+          if (layoutMode === "explorer" && !openTerminalFullscreen) {
+            setExplorerSelection({ machineId, sessionId: `pending-${sessionName}` });
+          } else {
+            handleOpenTerminal(machineId, sessionName, multiplexer);
+          }
+        }}
         initialMachineId={launchMachineId}
       />
       <ResumeAgentModal

--- a/dashboard/src/components/SettingsModal.tsx
+++ b/dashboard/src/components/SettingsModal.tsx
@@ -40,6 +40,7 @@ export function SettingsModal({ open, onClose }: Props): React.JSX.Element | nul
     theme: "dark",
     enableKeyboardNavigation: true,
     keyboardShortcuts: { ...DEFAULT_KEYBOARD_SHORTCUTS },
+    openTerminalFullscreen: true,
   });
   const [saving, setSaving] = useState(false);
 
@@ -447,6 +448,20 @@ export function SettingsModal({ open, onClose }: Props): React.JSX.Element | nul
                   placeholder="~ (home directory)"
                 />
                 <span className="form-hint">Pre-fills the project directory when launching new agents</span>
+              </div>
+              <div className="form-group">
+                <label className="form-toggle-row">
+                  <input
+                    type="checkbox"
+                    checked={settings.openTerminalFullscreen}
+                    onChange={(e) => setSettings({ ...settings, openTerminalFullscreen: e.target.checked })}
+                    aria-label="Open terminal fullscreen on new session"
+                  />
+                  <span className="form-toggle-label">Open terminal fullscreen on new session</span>
+                </label>
+                <span className="form-hint">
+                  Explorer layout only. When disabled, new sessions open in the detail pane instead.
+                </span>
               </div>
               <div className="form-group">
                 <label className="form-toggle-row">

--- a/server/src/store.test.ts
+++ b/server/src/store.test.ts
@@ -7,6 +7,7 @@ import {
   getSavedSessionName,
   getSettings,
   renameSession,
+  updateSettings,
   upsertMachine,
 } from "./store";
 
@@ -376,5 +377,31 @@ describe("store", () => {
   test("default settings include openTerminalFullscreen as true", () => {
     const settings = getSettings();
     expect(settings.openTerminalFullscreen).toBe(true);
+  });
+
+  test("updateSettings toggles openTerminalFullscreen", () => {
+    const updated = updateSettings({ openTerminalFullscreen: false });
+    expect(updated.openTerminalFullscreen).toBe(false);
+
+    const retrieved = getSettings();
+    expect(retrieved.openTerminalFullscreen).toBe(false);
+
+    // Restore to default for other tests
+    updateSettings({ openTerminalFullscreen: true });
+  });
+
+  test("updateSettings preserves other settings when patching openTerminalFullscreen", () => {
+    const before = getSettings();
+    updateSettings({ openTerminalFullscreen: false });
+    const after = getSettings();
+
+    expect(after.openTerminalFullscreen).toBe(false);
+    expect(after.defaultMultiplexer).toBe(before.defaultMultiplexer);
+    expect(after.theme).toBe(before.theme);
+    expect(after.fontSize).toBe(before.fontSize);
+    expect(after.enableKeyboardNavigation).toBe(before.enableKeyboardNavigation);
+
+    // Restore
+    updateSettings({ openTerminalFullscreen: true });
   });
 });

--- a/server/src/store.test.ts
+++ b/server/src/store.test.ts
@@ -5,6 +5,7 @@ import {
   getAllMachines,
   getMachine,
   getSavedSessionName,
+  getSettings,
   renameSession,
   upsertMachine,
 } from "./store";
@@ -370,5 +371,10 @@ describe("store", () => {
     const machines = getAllMachines();
     const expired = machines.find((m) => m.machineId === "expired-machine");
     expect(expired).toBeUndefined();
+  });
+
+  test("default settings include openTerminalFullscreen as true", () => {
+    const settings = getSettings();
+    expect(settings.openTerminalFullscreen).toBe(true);
   });
 });

--- a/server/src/store.ts
+++ b/server/src/store.ts
@@ -278,6 +278,7 @@ let settings: Settings = {
   theme: "dark",
   enableKeyboardNavigation: true,
   keyboardShortcuts: { ...DEFAULT_KEYBOARD_SHORTCUTS },
+  openTerminalFullscreen: true,
 };
 
 function loadSettings(): void {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -95,6 +95,7 @@ export interface Settings {
   theme: "dark" | "light";
   enableKeyboardNavigation: boolean;
   keyboardShortcuts: Record<string, string>;
+  openTerminalFullscreen: boolean;
 }
 
 export const DEFAULT_KEYBOARD_SHORTCUTS: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Add `openTerminalFullscreen` boolean setting (default: `true`) to control whether new sessions open in fullscreen terminal overlay
- When disabled in Explorer layout, new sessions auto-select in the explorer detail pane instead
- Cards layout behavior unchanged regardless of setting
- Setting accessible in Settings Modal under "Agent Defaults" tab

## Changes
- `shared/src/index.ts` — Add `openTerminalFullscreen` to Settings interface
- `server/src/store.ts` — Add default value for new setting
- `dashboard/src/components/SettingsModal.tsx` — Add toggle in Agent Defaults tab
- `dashboard/src/App.tsx` — Check setting in onLaunched callback, conditionally auto-select in explorer
- `server/src/store.test.ts` — Test for default settings

## Test Plan
- [x] Default settings include `openTerminalFullscreen: true`
- [x] Setting saves and loads correctly (uses existing Settings API)
- [x] Backward compatibility: old settings files without field get default `true` via spread pattern
- [x] All existing tests pass (609 non-dashboard tests, 4 pre-existing dashboard module resolution errors in worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)