### PR TITLE
fix(dashboard): prevent duplicate terminal connections when opening fullscreen

### DIFF
--- a/dashboard/src/components/SessionDetail.tsx
+++ b/dashboard/src/components/SessionDetail.tsx
@@ -645,9 +645,10 @@ export function SessionDetail({
                   <button
                     type="button"
                     className="action-btn terminal-btn"
-                    onClick={() =>
-                      onOpenTerminalFullscreen(session.multiplexerSession ?? "", session.multiplexer ?? "zellij")
-                    }
+                    onClick={() => {
+                      setActiveTab("chat");
+                      onOpenTerminalFullscreen(session.multiplexerSession ?? "", session.multiplexer ?? "zellij");
+                    }}
                     aria-label="Open terminal in fullscreen"
                   >
                     Fullscreen

--- a/server/src/store.test.ts
+++ b/server/src/store.test.ts
@@ -675,12 +675,16 @@ describe("store", () => {
       multiplexerSession: "my-session",
       multiplexer: "tmux" as const,
     };
-    upsertMachine(makeHeartbeat({ machineId: "persist-transfer", hostname: "persist-transfer-host", sessions: [session] }));
+    upsertMachine(
+      makeHeartbeat({ machineId: "persist-transfer", hostname: "persist-transfer-host", sessions: [session] }),
+    );
 
     expect(getMachine("persist-transfer")?.sessions[0].customName).toBe("my-session");
 
     // Second heartbeat: pending is already removed, name should survive via saved names
-    upsertMachine(makeHeartbeat({ machineId: "persist-transfer", hostname: "persist-transfer-host", sessions: [session] }));
+    upsertMachine(
+      makeHeartbeat({ machineId: "persist-transfer", hostname: "persist-transfer-host", sessions: [session] }),
+    );
 
     expect(getMachine("persist-transfer")?.sessions[0].customName).toBe("my-session");
     expect(getSavedSessionName("uuid-persist-transfer")).toBe("my-session");


### PR DESCRIPTION
## Summary
- Fix duplicate WebSocket terminal connections when opening fullscreen from Explorer's terminal tab
- When clicking "Fullscreen" in SessionDetail, the detail view's TerminalPane stayed mounted alongside the TerminalOverlay, creating two simultaneous connections to the same multiplexer session
- Fix: switch active tab to "chat" before opening fullscreen overlay, which unmounts the detail TerminalPane and closes its WebSocket

## Changes
- `dashboard/src/components/SessionDetail.tsx` — Switch activeTab to "chat" in Fullscreen button onClick handler before calling onOpenTerminalFullscreen

## Test Plan
- [x] Biome lint passes
- [x] Manual verification: only one mux connection when opening fullscreen terminal

Generated with [Claude Code](https://claude.com/claude-code)