### PR TITLE
fix(server): add timeouts to agent proxy requests to prevent server hangs

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,6 +10,7 @@ import {
   type UpdateNodeRequest,
   type WebSocketMessage,
 } from "@agent-town/shared";
+import { broadcastToClients, PROXY_LAUNCH_TIMEOUT_MS, proxyFetch, WS_CONNECT_TIMEOUT_MS } from "./proxy-fetch";
 import { connectAutoNodes, connectNode, disconnectNode, resolveAgentEndpoint, testNodeConnection } from "./ssh-manager";
 import {
   addPendingSession,
@@ -62,15 +63,8 @@ function getAgentUrl(
   return url;
 }
 
-function broadcastToClients(message: WebSocketMessage): void {
-  const data = JSON.stringify(message);
-  for (const client of wsClients) {
-    try {
-      client.send(data);
-    } catch (_err) {
-      wsClients.delete(client);
-    }
-  }
+function broadcast(message: WebSocketMessage): void {
+  broadcastToClients(wsClients, message);
 }
 
 const SECURITY_HEADERS: Record<string, string> = {
@@ -164,7 +158,7 @@ async function routeRequest(
         machine.agentAddress = isLocal ? "localhost" : agentAddress;
       }
 
-      broadcastToClients({
+      broadcast({
         type: "machines_update",
         payload: getAllMachines(),
       });
@@ -197,14 +191,12 @@ async function routeRequest(
       getAgentUrl(machine, "/api/session-messages") +
       `?sessionId=${encodeURIComponent(sessionId)}&agentType=${agentType}&offset=${offset}&limit=${limit}`;
 
-    try {
-      const agentResp = await fetch(agentUrl);
-      const data = await agentResp.json();
-      return Response.json(data, { status: agentResp.status });
-    } catch (err) {
-      log.error(`session-messages: failed to fetch from agent: ${err instanceof Error ? err.message : String(err)}`);
-      return Response.json({ error: "Failed to fetch messages from agent" }, { status: 502 });
+    const result = await proxyFetch(agentUrl);
+    if (!result.ok) {
+      return Response.json({ error: result.error, message: result.message }, { status: result.status });
     }
+    const data = await result.response.json();
+    return Response.json(data, { status: result.response.status });
   }
 
   // API: search session message content (proxy to agent)
@@ -226,14 +218,12 @@ async function routeRequest(
       getAgentUrl(machine, "/api/search-messages") +
       `?query=${encodeURIComponent(query)}&limit=${encodeURIComponent(limit)}`;
 
-    try {
-      const agentResp = await fetch(agentUrl);
-      const data = await agentResp.json();
-      return Response.json(data, { status: agentResp.status });
-    } catch (err) {
-      log.error(`search-messages: failed to fetch from agent: ${err instanceof Error ? err.message : String(err)}`);
-      return Response.json({ error: "Failed to search messages on agent" }, { status: 502 });
+    const result = await proxyFetch(agentUrl);
+    if (!result.ok) {
+      return Response.json({ error: result.error, message: result.message }, { status: result.status });
     }
+    const data = await result.response.json();
+    return Response.json(data, { status: result.response.status });
   }
 
   // API: get git diff for a session's working directory (proxy to agent)
@@ -252,14 +242,12 @@ async function routeRequest(
 
     const agentUrl = `${getAgentUrl(machine, "/api/git-diff")}?dir=${encodeURIComponent(dir)}`;
 
-    try {
-      const agentResp = await fetch(agentUrl);
-      const data = await agentResp.json();
-      return Response.json(data, { status: agentResp.status });
-    } catch (err) {
-      log.error(`git-diff: failed to fetch from agent: ${err instanceof Error ? err.message : String(err)}`);
-      return Response.json({ error: "Failed to fetch git diff from agent" }, { status: 502 });
+    const result = await proxyFetch(agentUrl);
+    if (!result.ok) {
+      return Response.json({ error: result.error, message: result.message }, { status: result.status });
     }
+    const data = await result.response.json();
+    return Response.json(data, { status: result.response.status });
   }
 
   // API: list directories on a machine (proxy to agent)
@@ -278,14 +266,12 @@ async function routeRequest(
 
     const agentUrl = `${getAgentUrl(machine, "/api/list-dirs")}?dir=${encodeURIComponent(dir)}`;
 
-    try {
-      const agentResp = await fetch(agentUrl);
-      const data = await agentResp.json();
-      return Response.json(data, { status: agentResp.status });
-    } catch (err) {
-      log.error(`list-dirs: failed to fetch from agent: ${err instanceof Error ? err.message : String(err)}`);
-      return Response.json({ error: "Failed to list directories from agent" }, { status: 502 });
+    const result = await proxyFetch(agentUrl);
+    if (!result.ok) {
+      return Response.json({ error: result.error, message: result.message }, { status: result.status });
     }
+    const data = await result.response.json();
+    return Response.json(data, { status: result.response.status });
   }
 
   // API: rename a session (also renames multiplexer session if active)
@@ -311,24 +297,22 @@ async function routeRequest(
           const machine = getMachine(body.machineId);
           if (machine?.terminalPort) {
             const agentUrl = getAgentUrl(machine, "/api/rename-session");
-            try {
-              const agentResp = await fetch(agentUrl, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  multiplexer: muxInfo.multiplexer,
-                  currentName: currentMuxName,
-                  newName: newMuxName,
-                }),
-              });
-              if (!agentResp.ok) {
-                const errText = await agentResp.text();
-                log.error(`rename: agent rename failed: ${errText}`);
-              } else {
-                log.info("rename: agent rename succeeded");
-              }
-            } catch (err) {
-              log.error(`rename: agent rename error: ${err instanceof Error ? err.message : String(err)}`);
+            const renameResult = await proxyFetch(agentUrl, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                multiplexer: muxInfo.multiplexer,
+                currentName: currentMuxName,
+                newName: newMuxName,
+              }),
+            });
+            if (!renameResult.ok) {
+              log.error(`rename: agent rename failed: ${renameResult.message}`);
+            } else if (!renameResult.response.ok) {
+              const errText = await renameResult.response.text();
+              log.error(`rename: agent rename failed: ${errText}`);
+            } else {
+              log.info("rename: agent rename succeeded");
             }
           } else {
             log.debug("rename: no terminalPort, skipping mux rename");
@@ -343,7 +327,7 @@ async function routeRequest(
         log.debug(`rename: UI-only (no active mux session)`);
       }
 
-      broadcastToClients({
+      broadcast({
         type: "machines_update",
         payload: getAllMachines(),
       });
@@ -370,7 +354,7 @@ async function routeRequest(
 
       const agentUrl = getAgentUrl(machine, "/api/kill");
 
-      const agentResp = await fetch(agentUrl, {
+      const result = await proxyFetch(agentUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -379,7 +363,10 @@ async function routeRequest(
         }),
       });
 
-      if (!agentResp.ok) {
+      if (!result.ok) {
+        return Response.json({ error: result.error, message: result.message }, { status: result.status });
+      }
+      if (!result.response.ok) {
         return Response.json({ error: "Agent kill failed" }, { status: 502 });
       }
       return Response.json({ ok: true });
@@ -410,28 +397,33 @@ async function routeRequest(
       const muxType = body.multiplexer || getSessionMultiplexerInfo(body.machineId, body.sessionId)?.multiplexer;
       if (muxSession && muxType) {
         log.info(`delete: killing mux session=${muxSession} type=${muxType}`);
-        try {
-          const killUrl = getAgentUrl(machine, "/api/kill");
-          await fetch(killUrl, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ multiplexer: muxType, session: muxSession }),
-          });
-        } catch (err) {
-          log.debug("best-effort mux kill failed", { error: String(err) });
+        const killUrl = getAgentUrl(machine, "/api/kill");
+        const killResult = await proxyFetch(killUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ multiplexer: muxType, session: muxSession }),
+        });
+        if (!killResult.ok) {
+          log.debug(`best-effort mux kill failed: ${killResult.message}`);
         }
       }
 
       // Step 3: Delete the JSONL file
       const deleteUrl = getAgentUrl(machine, "/api/delete-session");
-      const agentResp = await fetch(deleteUrl, {
+      const deleteResult = await proxyFetch(deleteUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ sessionId: body.sessionId }),
       });
 
-      if (!agentResp.ok) {
-        const errText = await agentResp.text();
+      if (!deleteResult.ok) {
+        return Response.json(
+          { error: deleteResult.error, message: deleteResult.message },
+          { status: deleteResult.status },
+        );
+      }
+      if (!deleteResult.response.ok) {
+        const errText = await deleteResult.response.text();
         return Response.json({ error: errText || "Delete failed" }, { status: 502 });
       }
 
@@ -463,7 +455,7 @@ async function routeRequest(
 
       const agentUrl = getAgentUrl(machine, "/api/send");
 
-      const agentResp = await fetch(agentUrl, {
+      const result = await proxyFetch(agentUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -474,7 +466,10 @@ async function routeRequest(
         }),
       });
 
-      if (!agentResp.ok) {
+      if (!result.ok) {
+        return Response.json({ error: result.error, message: result.message }, { status: result.status });
+      }
+      if (!result.response.ok) {
         return Response.json({ error: "Agent send failed" }, { status: 502 });
       }
       return Response.json({ ok: true });
@@ -504,7 +499,7 @@ async function routeRequest(
 
       const agentUrl = getAgentUrl(machine, "/api/reconnect");
 
-      const agentResp = await fetch(agentUrl, {
+      const result = await proxyFetch(agentUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -516,8 +511,11 @@ async function routeRequest(
         }),
       });
 
-      if (!agentResp.ok) {
-        const errText = await agentResp.text();
+      if (!result.ok) {
+        return Response.json({ error: result.error, message: result.message }, { status: result.status });
+      }
+      if (!result.response.ok) {
+        const errText = await result.response.text();
         return Response.json({ error: errText || "Agent reconnect failed" }, { status: 502 });
       }
       return Response.json({ ok: true });
@@ -558,29 +556,36 @@ async function routeRequest(
 
       const agentUrl = getAgentUrl(machine, "/api/launch");
 
-      const agentResp = await fetch(agentUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sessionName: body.sessionName,
-          projectDir: body.projectDir,
-          agentType: body.agentType || settings.defaultAgentType,
-          multiplexer: mux,
-          zellijLayout: settings.zellijLayout,
-          model: settings.defaultModel,
-          autonomous: body.autonomous,
-        }),
-      });
+      const result = await proxyFetch(
+        agentUrl,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sessionName: body.sessionName,
+            projectDir: body.projectDir,
+            agentType: body.agentType || settings.defaultAgentType,
+            multiplexer: mux,
+            zellijLayout: settings.zellijLayout,
+            model: settings.defaultModel,
+            autonomous: body.autonomous,
+          }),
+        },
+        PROXY_LAUNCH_TIMEOUT_MS,
+      );
 
-      if (!agentResp.ok) {
-        const errText = await agentResp.text();
+      if (!result.ok) {
+        return Response.json({ error: result.error, message: result.message }, { status: result.status });
+      }
+      if (!result.response.ok) {
+        const errText = await result.response.text();
         return Response.json({ error: errText || "Agent launch failed" }, { status: 502 });
       }
 
       // Add a pending session so the dashboard shows it immediately
       // (before the next heartbeat discovers the real session)
       addPendingSession(body.machineId, body.sessionName, body.projectDir, mux);
-      broadcastToClients({
+      broadcast({
         type: "machines_update",
         payload: getAllMachines(),
       });
@@ -618,23 +623,30 @@ async function routeRequest(
       const rawName = savedName || slug || body.sessionId.slice(0, 8);
       const sessionName = rawName.replace(/[^a-zA-Z0-9._-]/g, "-").slice(0, 50);
 
-      const agentResp = await fetch(agentUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sessionName,
-          sessionId: body.sessionId,
-          projectDir: body.projectDir,
-          agentType: body.agentType || settings.defaultAgentType,
-          multiplexer: settings.defaultMultiplexer,
-          zellijLayout: settings.zellijLayout,
-          model: settings.defaultModel,
-          autonomous: body.autonomous,
-        }),
-      });
+      const result = await proxyFetch(
+        agentUrl,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sessionName,
+            sessionId: body.sessionId,
+            projectDir: body.projectDir,
+            agentType: body.agentType || settings.defaultAgentType,
+            multiplexer: settings.defaultMultiplexer,
+            zellijLayout: settings.zellijLayout,
+            model: settings.defaultModel,
+            autonomous: body.autonomous,
+          }),
+        },
+        PROXY_LAUNCH_TIMEOUT_MS,
+      );
 
-      if (!agentResp.ok) {
-        const errText = await agentResp.text();
+      if (!result.ok) {
+        return Response.json({ error: result.error, message: result.message }, { status: result.status });
+      }
+      if (!result.response.ok) {
+        const errText = await result.response.text();
         return Response.json({ error: errText || "Agent resume failed" }, { status: 502 });
       }
       return Response.json({
@@ -817,7 +829,22 @@ const _server = Bun.serve({
 
         agentWs.binaryType = "arraybuffer";
 
+        // Connection timeout — close if agent doesn't respond within WS_CONNECT_TIMEOUT_MS
+        const connectTimeout = setTimeout(() => {
+          if (agentWs.readyState !== WebSocket.OPEN) {
+            log.warn(`ws: terminal proxy connection timeout for session=${session} agent=${agentHost}:${agentPort}`);
+            try {
+              ws.send("\r\n\x1b[31mConnection to agent terminal timed out\x1b[0m\r\n");
+              ws.close();
+            } catch (_err) {
+              // already closed
+            }
+            agentWs.close();
+          }
+        }, WS_CONNECT_TIMEOUT_MS);
+
         agentWs.onopen = () => {
+          clearTimeout(connectTimeout);
           log.debug(`ws: terminal proxy established for session=${session}`);
         };
 
@@ -834,6 +861,7 @@ const _server = Bun.serve({
         };
 
         agentWs.onclose = () => {
+          clearTimeout(connectTimeout);
           try {
             ws.close();
           } catch (_err) {
@@ -843,6 +871,7 @@ const _server = Bun.serve({
         };
 
         agentWs.onerror = () => {
+          clearTimeout(connectTimeout);
           log.warn(`ws: terminal proxy error for session=${session} agent=${agentHost}:${agentPort}`);
           try {
             ws.send("\r\n\x1b[31mFailed to connect to agent terminal server\x1b[0m\r\n");
@@ -869,8 +898,8 @@ const _server = Bun.serve({
     },
 
     close(ws) {
-      // Clean up dashboard clients
-      for (const client of wsClients) {
+      // Clean up dashboard clients — copy to array to avoid mutation during iteration
+      for (const client of [...wsClients]) {
         if (client.ws === ws) {
           wsClients.delete(client);
           break;

--- a/server/src/proxy-fetch.test.ts
+++ b/server/src/proxy-fetch.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { broadcastToClients, PROXY_LAUNCH_TIMEOUT_MS, PROXY_TIMEOUT_MS, proxyFetch } from "./proxy-fetch";
+
+describe("proxyFetch", () => {
+	test("returns response data on successful fetch", async () => {
+		const mockData = { sessions: ["s1", "s2"] };
+		const mockResponse = new Response(JSON.stringify(mockData), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = mock(() => Promise.resolve(mockResponse));
+
+		try {
+			const result = await proxyFetch("http://localhost:4681/api/sessions");
+			expect(result.ok).toBe(true);
+			expect(result.response).toBeInstanceOf(Response);
+			expect(result.response?.status).toBe(200);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test("returns timeout error when agent does not respond in time", async () => {
+		const originalFetch = globalThis.fetch;
+		// Simulate a fetch that never resolves until aborted
+		globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+			return new Promise<Response>((_resolve, reject) => {
+				if (init?.signal) {
+					init.signal.addEventListener("abort", () => {
+						reject(new DOMException("The operation was aborted.", "AbortError"));
+					});
+				}
+			});
+		});
+
+		try {
+			const result = await proxyFetch("http://unreachable:4681/api/sessions", {}, 50);
+			expect(result.ok).toBe(false);
+			expect(result.status).toBe(504);
+			expect(result.error).toBe("agent_timeout");
+			expect(result.message).toContain("did not respond");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test("returns network error on ECONNREFUSED", async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = mock(() => Promise.reject(new Error("fetch failed: ECONNREFUSED")));
+
+		try {
+			const result = await proxyFetch("http://dead-host:4681/api/sessions");
+			expect(result.ok).toBe(false);
+			expect(result.status).toBe(502);
+			expect(result.error).toBe("agent_unreachable");
+			expect(result.message).toContain("ECONNREFUSED");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test("forwards request init options (method, headers, body)", async () => {
+		const originalFetch = globalThis.fetch;
+		let capturedUrl = "";
+		let capturedInit: RequestInit | undefined;
+		globalThis.fetch = mock((url: string, init?: RequestInit) => {
+			capturedUrl = url;
+			capturedInit = init;
+			return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+		});
+
+		try {
+			const body = JSON.stringify({ session: "test" });
+			await proxyFetch("http://localhost:4681/api/kill", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body,
+			});
+
+			expect(capturedUrl).toBe("http://localhost:4681/api/kill");
+			expect(capturedInit?.method).toBe("POST");
+			expect(capturedInit?.body).toBe(body);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test("uses default timeout from PROXY_TIMEOUT_MS", () => {
+		expect(PROXY_TIMEOUT_MS).toBe(10_000);
+	});
+
+	test("has a longer timeout for launch/resume operations", () => {
+		expect(PROXY_LAUNCH_TIMEOUT_MS).toBe(30_000);
+	});
+
+	test("attaches AbortSignal.timeout to fetch calls", async () => {
+		const originalFetch = globalThis.fetch;
+		let capturedSignal: AbortSignal | undefined;
+		globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+			capturedSignal = init?.signal ?? undefined;
+			return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+		});
+
+		try {
+			await proxyFetch("http://localhost:4681/api/test");
+			expect(capturedSignal).toBeDefined();
+			expect(capturedSignal).toBeInstanceOf(AbortSignal);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
+describe("broadcastToClients", () => {
+	test("sends message to all connected clients", () => {
+		const sent: string[] = [];
+		const clients = new Set([
+			{ ws: {}, send: (data: string) => sent.push(data) },
+			{ ws: {}, send: (data: string) => sent.push(data) },
+		]);
+
+		broadcastToClients(clients, { type: "machines_update", payload: [] });
+
+		expect(sent).toHaveLength(2);
+		const parsed = JSON.parse(sent[0]);
+		expect(parsed.type).toBe("machines_update");
+	});
+
+	test("removes failed clients without crashing", () => {
+		const clients = new Set([
+			{
+				ws: {},
+				send: () => {
+					throw new Error("connection lost");
+				},
+			},
+			{ ws: {}, send: (_data: string) => {} },
+		]);
+
+		// Should not throw
+		expect(() => broadcastToClients(clients, { type: "machines_update", payload: [] })).not.toThrow();
+
+		// The failed client should have been removed
+		expect(clients.size).toBe(1);
+	});
+
+	test("handles empty client set", () => {
+		const clients = new Set<{ ws: unknown; send: (data: string) => void }>();
+		expect(() => broadcastToClients(clients, { type: "machines_update", payload: [] })).not.toThrow();
+	});
+
+	test("does not crash when all clients fail", () => {
+		const clients = new Set([
+			{
+				ws: {},
+				send: () => {
+					throw new Error("gone");
+				},
+			},
+			{
+				ws: {},
+				send: () => {
+					throw new Error("also gone");
+				},
+			},
+		]);
+
+		expect(() => broadcastToClients(clients, { type: "machines_update", payload: [] })).not.toThrow();
+		expect(clients.size).toBe(0);
+	});
+
+	test("iterates safely despite concurrent Set mutation", () => {
+		// This tests that broadcastToClients copies the set before iterating
+		// so that deleting during iteration doesn't cause issues
+		const goodSent: string[] = [];
+		const failClient = {
+			ws: {},
+			send: () => {
+				throw new Error("fail");
+			},
+		};
+		const goodClient = {
+			ws: {},
+			send: (data: string) => goodSent.push(data),
+		};
+
+		const clients = new Set([failClient, goodClient]);
+
+		broadcastToClients(clients, { type: "machines_update", payload: [] });
+
+		// Good client should still receive the message
+		expect(goodSent).toHaveLength(1);
+		// Failed client should be removed
+		expect(clients.has(failClient)).toBe(false);
+		expect(clients.has(goodClient)).toBe(true);
+	});
+});

--- a/server/src/proxy-fetch.test.ts
+++ b/server/src/proxy-fetch.test.ts
@@ -29,7 +29,7 @@ describe("proxyFetch", () => {
       return new Promise<Response>((_resolve, reject) => {
         if (init?.signal) {
           init.signal.addEventListener("abort", () => {
-            reject(new DOMException("The operation was aborted.", "AbortError"));
+            reject(new DOMException("The operation timed out.", "TimeoutError"));
           });
         }
       });

--- a/server/src/proxy-fetch.test.ts
+++ b/server/src/proxy-fetch.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, mock, test } from "bun:test";
-import { broadcastToClients, PROXY_LAUNCH_TIMEOUT_MS, PROXY_TIMEOUT_MS, proxyFetch } from "./proxy-fetch";
+import {
+  broadcastToClients,
+  PROXY_LAUNCH_TIMEOUT_MS,
+  PROXY_TIMEOUT_MS,
+  proxyFetch,
+  WS_CONNECT_TIMEOUT_MS,
+} from "./proxy-fetch";
 
 describe("proxyFetch", () => {
   test("returns response data on successful fetch", async () => {
@@ -107,6 +113,89 @@ describe("proxyFetch", () => {
       await proxyFetch("http://localhost:4681/api/test");
       expect(capturedSignal).toBeDefined();
       expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("treats AbortError the same as TimeoutError (504 response)", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() => Promise.reject(new DOMException("The operation was aborted.", "AbortError")));
+
+    try {
+      const result = await proxyFetch("http://localhost:4681/api/sessions");
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe(504);
+      expect(result.error).toBe("agent_timeout");
+      expect(result.message).toContain("did not respond");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns ok: true for non-200 agent responses (caller checks response.ok)", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ error: "not found" }), { status: 404 })),
+    );
+
+    try {
+      const result = await proxyFetch("http://localhost:4681/api/sessions");
+      // proxyFetch itself succeeds — the response reached us
+      expect(result.ok).toBe(true);
+      expect(result.response).toBeInstanceOf(Response);
+      expect(result.response?.status).toBe(404);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("handles non-Error throwable in catch path", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() => Promise.reject("string error"));
+
+    try {
+      const result = await proxyFetch("http://localhost:4681/api/sessions");
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe(502);
+      expect(result.error).toBe("agent_unreachable");
+      expect(result.message).toBe("string error");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("uses custom timeout when provided", async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedSignal: AbortSignal | undefined;
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      capturedSignal = init?.signal ?? undefined;
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    });
+
+    try {
+      await proxyFetch("http://localhost:4681/api/launch", {}, 30_000);
+      expect(capturedSignal).toBeDefined();
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("WS_CONNECT_TIMEOUT_MS is 10 seconds", () => {
+    expect(WS_CONNECT_TIMEOUT_MS).toBe(10_000);
+  });
+
+  test("timeout message includes rounded timeout value in seconds", async () => {
+    const originalFetch = globalThis.fetch;
+    // Simulate a timeout with a DOMException but control the timeoutMs parameter
+    // to verify the message formatting without waiting
+    globalThis.fetch = mock(() => Promise.reject(new DOMException("The operation timed out.", "TimeoutError")));
+
+    try {
+      const result = await proxyFetch("http://unreachable:4681/api/sessions", {}, 30_000);
+      expect(result.ok).toBe(false);
+      expect(result.message).toBe("Agent did not respond within 30s");
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/server/src/proxy-fetch.test.ts
+++ b/server/src/proxy-fetch.test.ts
@@ -1,199 +1,199 @@
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { broadcastToClients, PROXY_LAUNCH_TIMEOUT_MS, PROXY_TIMEOUT_MS, proxyFetch } from "./proxy-fetch";
 
 describe("proxyFetch", () => {
-	test("returns response data on successful fetch", async () => {
-		const mockData = { sessions: ["s1", "s2"] };
-		const mockResponse = new Response(JSON.stringify(mockData), {
-			status: 200,
-			headers: { "Content-Type": "application/json" },
-		});
+  test("returns response data on successful fetch", async () => {
+    const mockData = { sessions: ["s1", "s2"] };
+    const mockResponse = new Response(JSON.stringify(mockData), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
 
-		const originalFetch = globalThis.fetch;
-		globalThis.fetch = mock(() => Promise.resolve(mockResponse));
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() => Promise.resolve(mockResponse));
 
-		try {
-			const result = await proxyFetch("http://localhost:4681/api/sessions");
-			expect(result.ok).toBe(true);
-			expect(result.response).toBeInstanceOf(Response);
-			expect(result.response?.status).toBe(200);
-		} finally {
-			globalThis.fetch = originalFetch;
-		}
-	});
+    try {
+      const result = await proxyFetch("http://localhost:4681/api/sessions");
+      expect(result.ok).toBe(true);
+      expect(result.response).toBeInstanceOf(Response);
+      expect(result.response?.status).toBe(200);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 
-	test("returns timeout error when agent does not respond in time", async () => {
-		const originalFetch = globalThis.fetch;
-		// Simulate a fetch that never resolves until aborted
-		globalThis.fetch = mock((_url: string, init?: RequestInit) => {
-			return new Promise<Response>((_resolve, reject) => {
-				if (init?.signal) {
-					init.signal.addEventListener("abort", () => {
-						reject(new DOMException("The operation was aborted.", "AbortError"));
-					});
-				}
-			});
-		});
+  test("returns timeout error when agent does not respond in time", async () => {
+    const originalFetch = globalThis.fetch;
+    // Simulate a fetch that never resolves until aborted
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        if (init?.signal) {
+          init.signal.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }
+      });
+    });
 
-		try {
-			const result = await proxyFetch("http://unreachable:4681/api/sessions", {}, 50);
-			expect(result.ok).toBe(false);
-			expect(result.status).toBe(504);
-			expect(result.error).toBe("agent_timeout");
-			expect(result.message).toContain("did not respond");
-		} finally {
-			globalThis.fetch = originalFetch;
-		}
-	});
+    try {
+      const result = await proxyFetch("http://unreachable:4681/api/sessions", {}, 50);
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe(504);
+      expect(result.error).toBe("agent_timeout");
+      expect(result.message).toContain("did not respond");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 
-	test("returns network error on ECONNREFUSED", async () => {
-		const originalFetch = globalThis.fetch;
-		globalThis.fetch = mock(() => Promise.reject(new Error("fetch failed: ECONNREFUSED")));
+  test("returns network error on ECONNREFUSED", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() => Promise.reject(new Error("fetch failed: ECONNREFUSED")));
 
-		try {
-			const result = await proxyFetch("http://dead-host:4681/api/sessions");
-			expect(result.ok).toBe(false);
-			expect(result.status).toBe(502);
-			expect(result.error).toBe("agent_unreachable");
-			expect(result.message).toContain("ECONNREFUSED");
-		} finally {
-			globalThis.fetch = originalFetch;
-		}
-	});
+    try {
+      const result = await proxyFetch("http://dead-host:4681/api/sessions");
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe(502);
+      expect(result.error).toBe("agent_unreachable");
+      expect(result.message).toContain("ECONNREFUSED");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 
-	test("forwards request init options (method, headers, body)", async () => {
-		const originalFetch = globalThis.fetch;
-		let capturedUrl = "";
-		let capturedInit: RequestInit | undefined;
-		globalThis.fetch = mock((url: string, init?: RequestInit) => {
-			capturedUrl = url;
-			capturedInit = init;
-			return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
-		});
+  test("forwards request init options (method, headers, body)", async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedUrl = "";
+    let capturedInit: RequestInit | undefined;
+    globalThis.fetch = mock((url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    });
 
-		try {
-			const body = JSON.stringify({ session: "test" });
-			await proxyFetch("http://localhost:4681/api/kill", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body,
-			});
+    try {
+      const body = JSON.stringify({ session: "test" });
+      await proxyFetch("http://localhost:4681/api/kill", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
 
-			expect(capturedUrl).toBe("http://localhost:4681/api/kill");
-			expect(capturedInit?.method).toBe("POST");
-			expect(capturedInit?.body).toBe(body);
-		} finally {
-			globalThis.fetch = originalFetch;
-		}
-	});
+      expect(capturedUrl).toBe("http://localhost:4681/api/kill");
+      expect(capturedInit?.method).toBe("POST");
+      expect(capturedInit?.body).toBe(body);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 
-	test("uses default timeout from PROXY_TIMEOUT_MS", () => {
-		expect(PROXY_TIMEOUT_MS).toBe(10_000);
-	});
+  test("uses default timeout from PROXY_TIMEOUT_MS", () => {
+    expect(PROXY_TIMEOUT_MS).toBe(10_000);
+  });
 
-	test("has a longer timeout for launch/resume operations", () => {
-		expect(PROXY_LAUNCH_TIMEOUT_MS).toBe(30_000);
-	});
+  test("has a longer timeout for launch/resume operations", () => {
+    expect(PROXY_LAUNCH_TIMEOUT_MS).toBe(30_000);
+  });
 
-	test("attaches AbortSignal.timeout to fetch calls", async () => {
-		const originalFetch = globalThis.fetch;
-		let capturedSignal: AbortSignal | undefined;
-		globalThis.fetch = mock((_url: string, init?: RequestInit) => {
-			capturedSignal = init?.signal ?? undefined;
-			return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
-		});
+  test("attaches AbortSignal.timeout to fetch calls", async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedSignal: AbortSignal | undefined;
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      capturedSignal = init?.signal ?? undefined;
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    });
 
-		try {
-			await proxyFetch("http://localhost:4681/api/test");
-			expect(capturedSignal).toBeDefined();
-			expect(capturedSignal).toBeInstanceOf(AbortSignal);
-		} finally {
-			globalThis.fetch = originalFetch;
-		}
-	});
+    try {
+      await proxyFetch("http://localhost:4681/api/test");
+      expect(capturedSignal).toBeDefined();
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 describe("broadcastToClients", () => {
-	test("sends message to all connected clients", () => {
-		const sent: string[] = [];
-		const clients = new Set([
-			{ ws: {}, send: (data: string) => sent.push(data) },
-			{ ws: {}, send: (data: string) => sent.push(data) },
-		]);
+  test("sends message to all connected clients", () => {
+    const sent: string[] = [];
+    const clients = new Set([
+      { ws: {}, send: (data: string) => sent.push(data) },
+      { ws: {}, send: (data: string) => sent.push(data) },
+    ]);
 
-		broadcastToClients(clients, { type: "machines_update", payload: [] });
+    broadcastToClients(clients, { type: "machines_update", payload: [] });
 
-		expect(sent).toHaveLength(2);
-		const parsed = JSON.parse(sent[0]);
-		expect(parsed.type).toBe("machines_update");
-	});
+    expect(sent).toHaveLength(2);
+    const parsed = JSON.parse(sent[0]);
+    expect(parsed.type).toBe("machines_update");
+  });
 
-	test("removes failed clients without crashing", () => {
-		const clients = new Set([
-			{
-				ws: {},
-				send: () => {
-					throw new Error("connection lost");
-				},
-			},
-			{ ws: {}, send: (_data: string) => {} },
-		]);
+  test("removes failed clients without crashing", () => {
+    const clients = new Set([
+      {
+        ws: {},
+        send: () => {
+          throw new Error("connection lost");
+        },
+      },
+      { ws: {}, send: (_data: string) => {} },
+    ]);
 
-		// Should not throw
-		expect(() => broadcastToClients(clients, { type: "machines_update", payload: [] })).not.toThrow();
+    // Should not throw
+    expect(() => broadcastToClients(clients, { type: "machines_update", payload: [] })).not.toThrow();
 
-		// The failed client should have been removed
-		expect(clients.size).toBe(1);
-	});
+    // The failed client should have been removed
+    expect(clients.size).toBe(1);
+  });
 
-	test("handles empty client set", () => {
-		const clients = new Set<{ ws: unknown; send: (data: string) => void }>();
-		expect(() => broadcastToClients(clients, { type: "machines_update", payload: [] })).not.toThrow();
-	});
+  test("handles empty client set", () => {
+    const clients = new Set<{ ws: unknown; send: (data: string) => void }>();
+    expect(() => broadcastToClients(clients, { type: "machines_update", payload: [] })).not.toThrow();
+  });
 
-	test("does not crash when all clients fail", () => {
-		const clients = new Set([
-			{
-				ws: {},
-				send: () => {
-					throw new Error("gone");
-				},
-			},
-			{
-				ws: {},
-				send: () => {
-					throw new Error("also gone");
-				},
-			},
-		]);
+  test("does not crash when all clients fail", () => {
+    const clients = new Set([
+      {
+        ws: {},
+        send: () => {
+          throw new Error("gone");
+        },
+      },
+      {
+        ws: {},
+        send: () => {
+          throw new Error("also gone");
+        },
+      },
+    ]);
 
-		expect(() => broadcastToClients(clients, { type: "machines_update", payload: [] })).not.toThrow();
-		expect(clients.size).toBe(0);
-	});
+    expect(() => broadcastToClients(clients, { type: "machines_update", payload: [] })).not.toThrow();
+    expect(clients.size).toBe(0);
+  });
 
-	test("iterates safely despite concurrent Set mutation", () => {
-		// This tests that broadcastToClients copies the set before iterating
-		// so that deleting during iteration doesn't cause issues
-		const goodSent: string[] = [];
-		const failClient = {
-			ws: {},
-			send: () => {
-				throw new Error("fail");
-			},
-		};
-		const goodClient = {
-			ws: {},
-			send: (data: string) => goodSent.push(data),
-		};
+  test("iterates safely despite concurrent Set mutation", () => {
+    // This tests that broadcastToClients copies the set before iterating
+    // so that deleting during iteration doesn't cause issues
+    const goodSent: string[] = [];
+    const failClient = {
+      ws: {},
+      send: () => {
+        throw new Error("fail");
+      },
+    };
+    const goodClient = {
+      ws: {},
+      send: (data: string) => goodSent.push(data),
+    };
 
-		const clients = new Set([failClient, goodClient]);
+    const clients = new Set([failClient, goodClient]);
 
-		broadcastToClients(clients, { type: "machines_update", payload: [] });
+    broadcastToClients(clients, { type: "machines_update", payload: [] });
 
-		// Good client should still receive the message
-		expect(goodSent).toHaveLength(1);
-		// Failed client should be removed
-		expect(clients.has(failClient)).toBe(false);
-		expect(clients.has(goodClient)).toBe(true);
-	});
+    // Good client should still receive the message
+    expect(goodSent).toHaveLength(1);
+    // Failed client should be removed
+    expect(clients.has(failClient)).toBe(false);
+    expect(clients.has(goodClient)).toBe(true);
+  });
 });

--- a/server/src/proxy-fetch.ts
+++ b/server/src/proxy-fetch.ts
@@ -1,0 +1,91 @@
+import { createLogger, type WebSocketMessage } from "@agent-town/shared";
+
+const log = createLogger("proxy");
+
+/** Default timeout for data-read proxy requests (10 seconds) */
+export const PROXY_TIMEOUT_MS = 10_000;
+
+/** Longer timeout for agent launch/resume operations (30 seconds) */
+export const PROXY_LAUNCH_TIMEOUT_MS = 30_000;
+
+/** WebSocket connection timeout (10 seconds) */
+export const WS_CONNECT_TIMEOUT_MS = 10_000;
+
+interface ProxyFetchSuccess {
+	ok: true;
+	response: Response;
+	status?: undefined;
+	error?: undefined;
+	message?: undefined;
+}
+
+interface ProxyFetchError {
+	ok: false;
+	response?: undefined;
+	status: number;
+	error: string;
+	message: string;
+}
+
+type ProxyFetchResult = ProxyFetchSuccess | ProxyFetchError;
+
+/**
+ * Fetch wrapper that adds an AbortSignal.timeout to prevent hanging
+ * when an agent machine becomes unreachable.
+ *
+ * Returns a discriminated union so callers can check `result.ok` to
+ * determine if the fetch succeeded or timed out / failed.
+ */
+export async function proxyFetch(
+	url: string,
+	init: RequestInit = {},
+	timeoutMs: number = PROXY_TIMEOUT_MS,
+): Promise<ProxyFetchResult> {
+	try {
+		const response = await fetch(url, {
+			...init,
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+		return { ok: true, response };
+	} catch (err) {
+		const errMsg = err instanceof Error ? err.message : String(err);
+
+		if (err instanceof DOMException && err.name === "AbortError") {
+			log.warn(`proxy timeout after ${timeoutMs}ms: ${url}`);
+			return {
+				ok: false,
+				status: 504,
+				error: "agent_timeout",
+				message: `Agent did not respond within ${Math.round(timeoutMs / 1000)}s`,
+			};
+		}
+
+		log.error(`proxy fetch failed: ${url} — ${errMsg}`);
+		return {
+			ok: false,
+			status: 502,
+			error: "agent_unreachable",
+			message: errMsg,
+		};
+	}
+}
+
+type WsClient = { ws: unknown; send: (data: string) => void };
+
+/**
+ * Broadcast a WebSocket message to all connected dashboard clients.
+ * Copies the Set before iterating to avoid issues with concurrent mutation
+ * when a failed client is removed during the loop.
+ */
+export function broadcastToClients(wsClients: Set<WsClient>, message: WebSocketMessage): void {
+	const data = JSON.stringify(message);
+	const clients = [...wsClients];
+	for (const client of clients) {
+		try {
+			client.send(data);
+		} catch (err) {
+			log.debug(`broadcast: removing failed client: ${err instanceof Error ? err.message : String(err)}`);
+			wsClients.delete(client);
+		}
+	}
+}

--- a/server/src/proxy-fetch.ts
+++ b/server/src/proxy-fetch.ts
@@ -50,7 +50,7 @@ export async function proxyFetch(
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
 
-    if (err instanceof DOMException && err.name === "AbortError") {
+    if (err instanceof DOMException && (err.name === "TimeoutError" || err.name === "AbortError")) {
       log.warn(`proxy timeout after ${timeoutMs}ms: ${url}`);
       return {
         ok: false,

--- a/server/src/proxy-fetch.ts
+++ b/server/src/proxy-fetch.ts
@@ -12,19 +12,19 @@ export const PROXY_LAUNCH_TIMEOUT_MS = 30_000;
 export const WS_CONNECT_TIMEOUT_MS = 10_000;
 
 interface ProxyFetchSuccess {
-	ok: true;
-	response: Response;
-	status?: undefined;
-	error?: undefined;
-	message?: undefined;
+  ok: true;
+  response: Response;
+  status?: undefined;
+  error?: undefined;
+  message?: undefined;
 }
 
 interface ProxyFetchError {
-	ok: false;
-	response?: undefined;
-	status: number;
-	error: string;
-	message: string;
+  ok: false;
+  response?: undefined;
+  status: number;
+  error: string;
+  message: string;
 }
 
 type ProxyFetchResult = ProxyFetchSuccess | ProxyFetchError;
@@ -37,37 +37,37 @@ type ProxyFetchResult = ProxyFetchSuccess | ProxyFetchError;
  * determine if the fetch succeeded or timed out / failed.
  */
 export async function proxyFetch(
-	url: string,
-	init: RequestInit = {},
-	timeoutMs: number = PROXY_TIMEOUT_MS,
+  url: string,
+  init: RequestInit = {},
+  timeoutMs: number = PROXY_TIMEOUT_MS,
 ): Promise<ProxyFetchResult> {
-	try {
-		const response = await fetch(url, {
-			...init,
-			signal: AbortSignal.timeout(timeoutMs),
-		});
-		return { ok: true, response };
-	} catch (err) {
-		const errMsg = err instanceof Error ? err.message : String(err);
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return { ok: true, response };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
 
-		if (err instanceof DOMException && err.name === "AbortError") {
-			log.warn(`proxy timeout after ${timeoutMs}ms: ${url}`);
-			return {
-				ok: false,
-				status: 504,
-				error: "agent_timeout",
-				message: `Agent did not respond within ${Math.round(timeoutMs / 1000)}s`,
-			};
-		}
+    if (err instanceof DOMException && err.name === "AbortError") {
+      log.warn(`proxy timeout after ${timeoutMs}ms: ${url}`);
+      return {
+        ok: false,
+        status: 504,
+        error: "agent_timeout",
+        message: `Agent did not respond within ${Math.round(timeoutMs / 1000)}s`,
+      };
+    }
 
-		log.error(`proxy fetch failed: ${url} — ${errMsg}`);
-		return {
-			ok: false,
-			status: 502,
-			error: "agent_unreachable",
-			message: errMsg,
-		};
-	}
+    log.error(`proxy fetch failed: ${url} — ${errMsg}`);
+    return {
+      ok: false,
+      status: 502,
+      error: "agent_unreachable",
+      message: errMsg,
+    };
+  }
 }
 
 type WsClient = { ws: unknown; send: (data: string) => void };
@@ -78,14 +78,14 @@ type WsClient = { ws: unknown; send: (data: string) => void };
  * when a failed client is removed during the loop.
  */
 export function broadcastToClients(wsClients: Set<WsClient>, message: WebSocketMessage): void {
-	const data = JSON.stringify(message);
-	const clients = [...wsClients];
-	for (const client of clients) {
-		try {
-			client.send(data);
-		} catch (err) {
-			log.debug(`broadcast: removing failed client: ${err instanceof Error ? err.message : String(err)}`);
-			wsClients.delete(client);
-		}
-	}
+  const data = JSON.stringify(message);
+  const clients = [...wsClients];
+  for (const client of clients) {
+    try {
+      client.send(data);
+    } catch (err) {
+      log.debug(`broadcast: removing failed client: ${err instanceof Error ? err.message : String(err)}`);
+      wsClients.delete(client);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Add `AbortSignal.timeout()` to all 11 HTTP proxy requests from server to agents
- Add connection timeout to terminal WebSocket proxy (10s)
- Fix `broadcastToClients()` Set iteration safety (copy before iterating)
- Return structured HTTP 504 errors when agent is unreachable

## Changes
- `server/src/proxy-fetch.ts` — New module with `proxyFetch()` helper (timeout-aware fetch wrapper) and `broadcastToClients()` (mutation-safe Set iteration)
- `server/src/proxy-fetch.test.ts` — 12 tests covering timeout behavior, network errors, and broadcast safety
- `server/src/index.ts` — Replace all bare `fetch()` proxy calls with `proxyFetch()`, add WS connection timeout, use extracted `broadcastToClients()`

## Test Plan
- [x] proxyFetch returns result on successful fetch
- [x] proxyFetch returns 504 error after timeout
- [x] proxyFetch handles network errors (ECONNREFUSED) gracefully
- [x] proxyFetch forwards request init options correctly
- [x] proxyFetch attaches AbortSignal to all calls
- [x] broadcastToClients sends to all clients
- [x] broadcastToClients removes failed clients without crashing
- [x] broadcastToClients handles empty client set
- [x] broadcastToClients handles all clients failing
- [x] broadcastToClients iterates safely despite concurrent Set mutation
- [x] All 71 server tests pass (no regressions)
- [x] All 737 non-dashboard tests pass

Generated with [Claude Code](https://claude.com/claude-code)