### PR TITLE
fix: session stability improvements (disconnect, duplication, reboot)

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -18,7 +18,7 @@ import { discoverProcessMappings, type ProcessMapping } from "./process-mapper";
 import type { OpenCodeProvider } from "./providers/opencode/index";
 import { getAllProviders, getProvider, initializeProviders } from "./providers/registry";
 import { discoverSessions } from "./session-parser";
-import { startTerminalServer } from "./terminal-server";
+import { persistSessionId, startTerminalServer } from "./terminal-server";
 
 const log = createLogger("agent");
 
@@ -100,6 +100,11 @@ function loadSessionNames(): Record<string, string> {
  * Discover sessions from all providers and map them to multiplexer sessions
  * using process-level inspection. Validates that mapped multiplexer sessions
  * actually exist (rejects zombie process associations).
+ *
+ * Uses two mapping strategies:
+ * 1. Primary: match by session ID (from --resume args or JSONL birth time)
+ * 2. Fallback: match by CWD when session ID matching fails (handles delay
+ *    between process start and first JSONL creation)
  */
 function discoverAndMapSessions(
   sessions: SessionInfo[],
@@ -109,6 +114,7 @@ function discoverAndMapSessions(
   const activeMuxNames = new Set(multiplexerSessions.map((s) => s.name));
   log.debug(`active mux sessions: [${[...activeMuxNames].join(", ")}]`);
 
+  // Primary pass: match sessions by session ID
   for (const session of sessions) {
     const mapping = processMappings.get(session.sessionId);
     if (mapping) {
@@ -120,6 +126,25 @@ function discoverAndMapSessions(
           `rejected mapping: session=${truncateId(session.sessionId)} mux=${mapping.session} (not in active mux list)`,
         );
       }
+    }
+  }
+
+  // Fallback pass: for sessions still unmapped, try matching by CWD.
+  // This handles the case where the user delays before sending their first
+  // message — the JSONL file is created long after the process started,
+  // so birth-time matching fails and the mapping is keyed by "cwd:<path>"
+  // instead of by session ID.
+  const mappedMuxSessions = new Set(sessions.filter((s) => s.multiplexerSession).map((s) => s.multiplexerSession));
+  for (const session of sessions) {
+    if (session.multiplexerSession) continue; // already mapped
+    if (!session.cwd) continue;
+
+    const cwdMapping = processMappings.get(`cwd:${session.cwd}`);
+    if (cwdMapping && activeMuxNames.has(cwdMapping.session) && !mappedMuxSessions.has(cwdMapping.session)) {
+      session.multiplexer = cwdMapping.multiplexer;
+      session.multiplexerSession = cwdMapping.session;
+      mappedMuxSessions.add(cwdMapping.session);
+      log.debug(`cwd fallback: session=${truncateId(session.sessionId)} mux=${cwdMapping.session} cwd=${session.cwd}`);
     }
   }
 
@@ -256,6 +281,14 @@ async function sendHeartbeat(): Promise<void> {
     adjustSessionStatuses(sessions, processMappings);
     trackMultiplexerAssociations(sessions, multiplexerSessions);
     createPlaceholderSessions(sessions, processMappings, activeMuxNames);
+
+    // Persist session IDs for mapped sessions so the recovery wrapper
+    // script can use --resume on zellij session resurrection after reboot.
+    for (const session of sessions) {
+      if (session.multiplexerSession && !session.sessionId.startsWith("pending-")) {
+        persistSessionId(session.multiplexerSession, session.sessionId);
+      }
+    }
 
     // Only include active (non-exited) multiplexer sessions
     const activeMuxSessions = multiplexerSessions.filter((s) => s.attached);

--- a/agent/src/placeholder-sessions.ts
+++ b/agent/src/placeholder-sessions.ts
@@ -9,6 +9,10 @@ import type { ProcessMapping } from "./process-mapper";
  * any messages yet (no JSONL file). The process mapper finds the agent
  * process but discoverSessions() has nothing to report. Creates synthetic
  * sessions so the dashboard shows agents immediately.
+ *
+ * Skips placeholder creation when a real session with the same CWD already
+ * exists (even if unmapped) — this prevents duplication when the user delays
+ * before sending their first message and the birth-time matching fails.
  */
 export function createPlaceholderSessions(
   sessions: SessionInfo[],
@@ -16,6 +20,10 @@ export function createPlaceholderSessions(
   activeMuxNames: Set<string>,
 ): void {
   const mappedMuxSessions = new Set(sessions.filter((s) => s.multiplexerSession).map((s) => s.multiplexerSession));
+  // Track CWDs of real (non-placeholder) sessions to prevent duplication
+  const realSessionCwds = new Set(
+    sessions.filter((s) => !s.sessionId.startsWith("pending-") && s.cwd).map((s) => s.cwd),
+  );
 
   for (const [key, mapping] of processMappings) {
     if (mappedMuxSessions.has(mapping.session)) continue; // already mapped
@@ -23,6 +31,10 @@ export function createPlaceholderSessions(
 
     const cwd = key.startsWith("cwd:") ? key.slice(4) : "";
     if (!cwd) continue; // session ID-based key but no matching session — skip
+
+    // Skip if a real session already exists in this CWD — the CWD fallback
+    // in discoverAndMapSessions should have already mapped it
+    if (realSessionCwds.has(cwd)) continue;
 
     const placeholder: SessionInfo = {
       sessionId: `pending-${mapping.session}`,

--- a/agent/src/placeholder.test.ts
+++ b/agent/src/placeholder.test.ts
@@ -124,4 +124,77 @@ describe("createPlaceholderSessions", () => {
     expect(sessions).toHaveLength(1);
     expect(sessions[0].agentType).toBe("claude-code");
   });
+
+  test("skips placeholder when a real session with the same CWD already exists", () => {
+    // This handles the duplication bug: user delays before first message,
+    // so the JSONL session exists but hasn't been mapped to a multiplexer
+    // session yet (birth-time matching failed). Without this check, both
+    // the real session and a placeholder would appear in the dashboard.
+    const sessions: SessionInfo[] = [
+      {
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        agentType: "claude-code",
+        slug: "test",
+        projectPath: "/home/user/project",
+        projectName: "project",
+        gitBranch: "main",
+        status: "working",
+        lastActivity: new Date().toISOString(),
+        lastMessage: "Working",
+        cwd: "/home/user/project",
+        // Note: no multiplexerSession — mapping failed
+      },
+    ];
+    const processMappings = new Map<string, ProcessMapping>();
+    processMappings.set("cwd:/home/user/project", makeMapping({ session: "my-agent" }));
+    const activeMuxNames = new Set(["my-agent"]);
+
+    createPlaceholderSessions(sessions, processMappings, activeMuxNames);
+
+    // Should NOT create a placeholder because a real session shares the CWD
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].sessionId).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  test("still creates placeholder when no real session shares the CWD", () => {
+    // Truly new session: no JSONL at all, only a running process
+    const sessions: SessionInfo[] = [];
+    const processMappings = new Map<string, ProcessMapping>();
+    processMappings.set("cwd:/home/user/project", makeMapping({ session: "brand-new" }));
+    const activeMuxNames = new Set(["brand-new"]);
+
+    createPlaceholderSessions(sessions, processMappings, activeMuxNames);
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].sessionId).toBe("pending-brand-new");
+  });
+
+  test("does not skip placeholder based on another pending session CWD", () => {
+    // Only real (non-pending) sessions should suppress placeholder creation
+    const sessions: SessionInfo[] = [
+      {
+        sessionId: "pending-other-session",
+        agentType: "claude-code",
+        slug: "other",
+        projectPath: "/home/user/project",
+        projectName: "project",
+        gitBranch: "",
+        status: "starting",
+        lastActivity: new Date().toISOString(),
+        lastMessage: "Starting...",
+        cwd: "/home/user/project",
+        multiplexerSession: "other-session",
+        multiplexer: "zellij",
+      },
+    ];
+    const processMappings = new Map<string, ProcessMapping>();
+    processMappings.set("cwd:/home/user/project", makeMapping({ session: "new-agent" }));
+    const activeMuxNames = new Set(["new-agent", "other-session"]);
+
+    createPlaceholderSessions(sessions, processMappings, activeMuxNames);
+
+    // Should still create placeholder — the existing session is a pending-* too
+    expect(sessions).toHaveLength(2);
+    expect(sessions[1].sessionId).toBe("pending-new-agent");
+  });
 });

--- a/agent/src/terminal-server.test.ts
+++ b/agent/src/terminal-server.test.ts
@@ -1,8 +1,12 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import type { Server } from "bun";
 import {
   addRenameMapping,
   clearRenameMappings,
+  createSessionRecoveryFiles,
+  persistSessionId,
   resolveSessionName,
   startTerminalServer,
   validateModel,
@@ -136,6 +140,90 @@ describe("validateSessionId", () => {
     expect(validateSessionId("test;injection")).not.toBeNull();
     expect(validateSessionId("../../../etc")).not.toBeNull();
     expect(validateSessionId("id$(whoami)")).not.toBeNull();
+  });
+});
+
+describe("createSessionRecoveryFiles", () => {
+  // Use the real SESSIONS_DIR (~/.agent-town/sessions/) since the function
+  // writes there. Tests use unique session names to avoid collisions.
+  const testPrefix = `test-recovery-${Date.now()}`;
+
+  afterAll(() => {
+    // Clean up test session directories
+    const sessionsDir = join(process.env.HOME || "/tmp", ".agent-town", "sessions");
+    for (const name of [`${testPrefix}-basic`, `${testPrefix}-resume`, `${testPrefix}-flags`]) {
+      const dir = join(sessionsDir, name);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("creates run.sh and layout.kdl files", () => {
+    const sessionName = `${testPrefix}-basic`;
+    const layoutPath = createSessionRecoveryFiles(
+      sessionName,
+      "/home/user/project",
+      ["claude"],
+      ["claude", "--resume", "__SESSION_ID__"],
+    );
+
+    expect(existsSync(layoutPath)).toBe(true);
+    const scriptPath = layoutPath.replace("layout.kdl", "run.sh");
+    expect(existsSync(scriptPath)).toBe(true);
+  });
+
+  test("run.sh contains launch command and resume logic", () => {
+    const sessionName = `${testPrefix}-resume`;
+    const layoutPath = createSessionRecoveryFiles(
+      sessionName,
+      "/home/user/project",
+      ["claude", "--dangerously-skip-permissions"],
+      ["claude", "--resume", "__SESSION_ID__", "--dangerously-skip-permissions"],
+    );
+
+    const scriptPath = layoutPath.replace("layout.kdl", "run.sh");
+    const content = readFileSync(scriptPath, "utf-8");
+
+    // Should contain the project dir cd
+    expect(content).toContain("cd /home/user/project");
+    // Should contain the launch command as fallback
+    expect(content).toContain("claude --dangerously-skip-permissions");
+    // Should contain resume logic with session-id file check
+    expect(content).toContain('if [ -f "$SID_FILE" ]');
+    expect(content).toContain("--resume");
+    expect(content).toContain('"$SESSION_ID"');
+  });
+
+  test("layout.kdl references the run.sh script", () => {
+    const sessionName = `${testPrefix}-flags`;
+    const layoutPath = createSessionRecoveryFiles(
+      sessionName,
+      "/tmp/test",
+      ["claude"],
+      ["claude", "--resume", "__SESSION_ID__"],
+    );
+
+    const layout = readFileSync(layoutPath, "utf-8");
+    expect(layout).toContain('pane command="bash"');
+    expect(layout).toContain("run.sh");
+  });
+});
+
+describe("persistSessionId", () => {
+  const testPrefix = `test-persist-${Date.now()}`;
+
+  afterAll(() => {
+    const sessionsDir = join(process.env.HOME || "/tmp", ".agent-town", "sessions");
+    rmSync(join(sessionsDir, `${testPrefix}-sid`), { recursive: true, force: true });
+  });
+
+  test("writes session-id file for a multiplexer session", () => {
+    const sessionName = `${testPrefix}-sid`;
+    persistSessionId(sessionName, "550e8400-e29b-41d4-a716-446655440000");
+
+    const sessionsDir = join(process.env.HOME || "/tmp", ".agent-town", "sessions");
+    const sidPath = join(sessionsDir, sessionName, "session-id");
+    expect(existsSync(sidPath)).toBe(true);
+    expect(readFileSync(sidPath, "utf-8")).toBe("550e8400-e29b-41d4-a716-446655440000");
   });
 });
 

--- a/agent/src/terminal-server.ts
+++ b/agent/src/terminal-server.ts
@@ -1,7 +1,7 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { type AgentType, buildShellCommand, createLogger, truncateId } from "@agent-town/shared";
+import { type AgentType, buildShellCommand, createLogger, shellEscape, truncateId } from "@agent-town/shared";
 import type { Server, Subprocess } from "bun";
 import { fetchGitDiff, GitDiffError, validateDiffDir } from "./git-diff";
 import { configureLocalHooks } from "./hook-setup";
@@ -115,6 +115,91 @@ async function cleanupBeforeZellijCreate(name: string, env: Record<string, strin
         log.debug(`cleanup: stopped lingering scope ${unit}`);
       }
     }
+  }
+}
+
+// --- Session recovery scripts ---
+//
+// Each zellij session gets a wrapper script stored in
+// ~/.agent-town/sessions/<name>/run.sh. This script is used as the pane
+// command via a generated layout file. When zellij resurrects a session
+// after a reboot, it re-runs the pane command — the wrapper script checks
+// for a persisted session ID and uses --resume to continue the original
+// session instead of starting fresh.
+const SESSIONS_DIR = join(homedir(), ".agent-town", "sessions");
+
+/**
+ * Create the session wrapper script and layout file for a zellij session.
+ * The wrapper script runs the agent command, and on recovery checks for
+ * a persisted session-id file to use --resume automatically.
+ *
+ * Returns the path to the generated layout file.
+ */
+export function createSessionRecoveryFiles(
+  sessionName: string,
+  projectDir: string,
+  launchParts: string[],
+  resumeParts: string[],
+): string {
+  const sessionDir = join(SESSIONS_DIR, sessionName);
+  mkdirSync(sessionDir, { recursive: true });
+
+  const sessionIdPath = join(sessionDir, "session-id");
+  const scriptPath = join(sessionDir, "run.sh");
+  const layoutPath = join(sessionDir, "layout.kdl");
+
+  // Build shell-safe command strings
+  const launchCmd = launchParts.map(shellEscape).join(" ");
+  const resumeCmd = resumeParts.map(shellEscape).join(" ");
+
+  const script = [
+    "#!/bin/bash",
+    `cd ${shellEscape(projectDir)}`,
+    `SID_FILE=${shellEscape(sessionIdPath)}`,
+    `if [ -f "$SID_FILE" ]; then`,
+    `  SESSION_ID=$(cat "$SID_FILE")`,
+    // Replace the __SESSION_ID__ placeholder with the actual session ID
+    `  exec ${resumeCmd.replace(shellEscape("__SESSION_ID__"), '"$SESSION_ID"')}`,
+    "fi",
+    `exec ${launchCmd}`,
+    "",
+  ].join("\n");
+
+  writeFileSync(scriptPath, script);
+  chmodSync(scriptPath, 0o755);
+
+  // Generate a minimal KDL layout that runs the wrapper script as the pane command.
+  // Zellij stores this as the pane's command, so on session resurrection it re-runs
+  // the script (which checks for session-id and resumes if possible).
+  const layout = [
+    "layout {",
+    `    pane command="bash" {`,
+    `        args ${JSON.stringify(scriptPath)}`,
+    "    }",
+    "}",
+    "",
+  ].join("\n");
+
+  writeFileSync(layoutPath, layout);
+
+  log.info(`recovery: created session files for ${sessionName} at ${sessionDir}`);
+  return layoutPath;
+}
+
+/**
+ * Persist the session ID for a multiplexer session, enabling --resume on recovery.
+ * Called from the heartbeat loop when a JSONL session is mapped to a mux session.
+ */
+export function persistSessionId(multiplexerSession: string, sessionId: string): void {
+  const sessionDir = join(SESSIONS_DIR, multiplexerSession);
+  const sessionIdPath = join(sessionDir, "session-id");
+  try {
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(sessionIdPath, sessionId);
+  } catch (err) {
+    log.warn(
+      `recovery: failed to persist session-id for ${multiplexerSession}: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 
@@ -565,6 +650,22 @@ export function startTerminalServer(port: number, machineId: string): Server {
           // Clean up EXITED sessions and lingering scope units
           await cleanupBeforeZellijCreate(body.sessionName, cleanEnv);
 
+          // Create a wrapper script for session recovery. On zellij session
+          // resurrection after a reboot, zellij re-runs the pane command.
+          // The wrapper script checks for a persisted session-id and uses
+          // --resume to continue the original session instead of starting fresh.
+          const resumeParts = provider.buildResumeCommand({
+            sessionId: "__SESSION_ID__",
+            model: body.model,
+            autonomous: body.autonomous,
+          });
+          const recoveryLayoutPath = createSessionRecoveryFiles(
+            body.sessionName,
+            body.projectDir,
+            agentParts,
+            resumeParts,
+          );
+
           // Zellij: create session in its own cgroup scope (survives agent restarts)
           // Note: zellij -s panics with ENOTTY when spawned without a TTY,
           // but it still creates the session successfully.
@@ -593,8 +694,13 @@ export function startTerminalServer(port: number, machineId: string): Server {
             return false;
           }
 
-          // Try with layout first, then without (layout may not exist on remote machines)
-          let sessionReady = await tryCreateZellijSession(body.zellijLayout);
+          // Use the generated recovery layout so zellij stores the wrapper script
+          // as the pane command. Falls back to user layout, then no layout.
+          let sessionReady = await tryCreateZellijSession(recoveryLayoutPath);
+          if (!sessionReady) {
+            log.warn("launch: recovery layout failed, retrying with user layout");
+            sessionReady = await tryCreateZellijSession(body.zellijLayout);
+          }
           if (!sessionReady && body.zellijLayout) {
             log.warn(`launch: layout "${body.zellijLayout}" failed, retrying without layout`);
             sessionReady = await tryCreateZellijSession();
@@ -607,17 +713,10 @@ export function startTerminalServer(port: number, machineId: string): Server {
             );
           }
 
-          // Send cd + agent command via write-chars (include \n to execute)
-          const fullCmd = `${buildShellCommand(agentParts, body.projectDir)}\n`;
-          const writeChars = Bun.spawn(["zellij", "--session", body.sessionName, "action", "write-chars", fullCmd], {
-            env: cleanEnv,
-            stdout: "ignore",
-            stderr: "ignore",
-          });
-          await writeChars.exited;
-
           // CLI agent post-launch: auto-accept trust prompt,
           // autonomous disclaimer, and send initial "hi" to trigger session file.
+          // The agent command is already running via the recovery layout script,
+          // so we only need to handle interactive prompts via write-chars.
           if (agentType === "claude-code" || agentType === "gemini-cli") {
             await new Promise((r) => setTimeout(r, TRUST_PROMPT_DELAY_MS));
             Bun.spawn(["zellij", "--session", body.sessionName, "action", "write-chars", "\n"], {
@@ -751,7 +850,17 @@ export function startTerminalServer(port: number, machineId: string): Server {
           // Clean up EXITED sessions and lingering scope units
           await cleanupBeforeZellijCreate(body.sessionName, cleanEnv);
 
-          // Create zellij session — try with layout, fallback without
+          // Create recovery files. For resume, the session-id is already
+          // known so we write it immediately for reboot resilience.
+          const recoveryLayoutPath2 = createSessionRecoveryFiles(
+            body.sessionName,
+            body.projectDir,
+            agentParts, // launch cmd (fallback)
+            agentParts, // resume cmd (already includes --resume)
+          );
+          persistSessionId(body.sessionName, body.sessionId);
+
+          // Create zellij session — try recovery layout, user layout, then none
           async function tryCreateZellijSession2(layout?: string): Promise<boolean> {
             const args = ["zellij", "-s", body.sessionName];
             if (layout) args.push("-n", layout);
@@ -777,7 +886,11 @@ export function startTerminalServer(port: number, machineId: string): Server {
             return false;
           }
 
-          let sessionReady = await tryCreateZellijSession2(body.zellijLayout);
+          let sessionReady = await tryCreateZellijSession2(recoveryLayoutPath2);
+          if (!sessionReady) {
+            log.warn("resume: recovery layout failed, retrying with user layout");
+            sessionReady = await tryCreateZellijSession2(body.zellijLayout);
+          }
           if (!sessionReady && body.zellijLayout) {
             log.warn(`resume: layout "${body.zellijLayout}" failed, retrying without layout`);
             sessionReady = await tryCreateZellijSession2();
@@ -790,14 +903,8 @@ export function startTerminalServer(port: number, machineId: string): Server {
             );
           }
 
-          // Send resume command
-          const fullCmd = `${buildShellCommand(agentParts, body.projectDir)}\n`;
-          Bun.spawn(["zellij", "--session", body.sessionName, "action", "write-chars", fullCmd], {
-            env: cleanEnv,
-            stdout: "ignore",
-            stderr: "ignore",
-          });
-
+          // The agent command is already running via the recovery layout script.
+          // Auto-accept trust prompt for CLI agents.
           if (agentType === "claude-code" || agentType === "gemini-cli") {
             await new Promise((r) => setTimeout(r, TRUST_PROMPT_DELAY_MS));
             Bun.spawn(["zellij", "--session", body.sessionName, "action", "write-chars", "\n"], {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,6 +33,11 @@ import {
 const log = createLogger("server");
 
 const PORT = Number(process.env.AGENT_TOWN_PORT || "4680");
+
+// Timeout for proxied HTTP requests to agents.
+// When a remote machine disconnects or an SSH tunnel drops, fetch() calls
+// without a timeout hang indefinitely, causing the server to become unresponsive.
+const AGENT_PROXY_TIMEOUT_MS = 15_000;
 const DASHBOARD_DIR = join(import.meta.dir, "../../dashboard/dist");
 
 // Track connected dashboard WebSocket clients
@@ -64,12 +69,16 @@ function getAgentUrl(
 
 function broadcastToClients(message: WebSocketMessage): void {
   const data = JSON.stringify(message);
+  const failed: { ws: unknown; send: (data: string) => void }[] = [];
   for (const client of wsClients) {
     try {
       client.send(data);
     } catch (_err) {
-      wsClients.delete(client);
+      failed.push(client);
     }
+  }
+  for (const client of failed) {
+    wsClients.delete(client);
   }
 }
 
@@ -198,7 +207,7 @@ async function routeRequest(
       `?sessionId=${encodeURIComponent(sessionId)}&agentType=${agentType}&offset=${offset}&limit=${limit}`;
 
     try {
-      const agentResp = await fetch(agentUrl);
+      const agentResp = await fetch(agentUrl, { signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS) });
       const data = await agentResp.json();
       return Response.json(data, { status: agentResp.status });
     } catch (err) {
@@ -227,7 +236,7 @@ async function routeRequest(
       `?query=${encodeURIComponent(query)}&limit=${encodeURIComponent(limit)}`;
 
     try {
-      const agentResp = await fetch(agentUrl);
+      const agentResp = await fetch(agentUrl, { signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS) });
       const data = await agentResp.json();
       return Response.json(data, { status: agentResp.status });
     } catch (err) {
@@ -253,7 +262,7 @@ async function routeRequest(
     const agentUrl = `${getAgentUrl(machine, "/api/git-diff")}?dir=${encodeURIComponent(dir)}`;
 
     try {
-      const agentResp = await fetch(agentUrl);
+      const agentResp = await fetch(agentUrl, { signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS) });
       const data = await agentResp.json();
       return Response.json(data, { status: agentResp.status });
     } catch (err) {
@@ -279,7 +288,7 @@ async function routeRequest(
     const agentUrl = `${getAgentUrl(machine, "/api/list-dirs")}?dir=${encodeURIComponent(dir)}`;
 
     try {
-      const agentResp = await fetch(agentUrl);
+      const agentResp = await fetch(agentUrl, { signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS) });
       const data = await agentResp.json();
       return Response.json(data, { status: agentResp.status });
     } catch (err) {
@@ -320,6 +329,7 @@ async function routeRequest(
                   currentName: currentMuxName,
                   newName: newMuxName,
                 }),
+                signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS),
               });
               if (!agentResp.ok) {
                 const errText = await agentResp.text();
@@ -377,6 +387,7 @@ async function routeRequest(
           multiplexer: body.multiplexer,
           session: body.session,
         }),
+        signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS),
       });
 
       if (!agentResp.ok) {
@@ -416,6 +427,7 @@ async function routeRequest(
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ multiplexer: muxType, session: muxSession }),
+            signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS),
           });
         } catch (err) {
           log.debug("best-effort mux kill failed", { error: String(err) });
@@ -428,6 +440,7 @@ async function routeRequest(
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ sessionId: body.sessionId }),
+        signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS),
       });
 
       if (!agentResp.ok) {
@@ -472,6 +485,7 @@ async function routeRequest(
           session: body.session,
           text: body.text,
         }),
+        signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS),
       });
 
       if (!agentResp.ok) {
@@ -514,6 +528,7 @@ async function routeRequest(
           agentType: body.agentType || settings.defaultAgentType,
           model: settings.defaultModel,
         }),
+        signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS),
       });
 
       if (!agentResp.ok) {
@@ -570,6 +585,7 @@ async function routeRequest(
           model: settings.defaultModel,
           autonomous: body.autonomous,
         }),
+        signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS),
       });
 
       if (!agentResp.ok) {
@@ -631,6 +647,7 @@ async function routeRequest(
           model: settings.defaultModel,
           autonomous: body.autonomous,
         }),
+        signal: AbortSignal.timeout(AGENT_PROXY_TIMEOUT_MS),
       });
 
       if (!agentResp.ok) {
@@ -829,21 +846,23 @@ const _server = Bun.serve({
               ws.send(event.data);
             }
           } catch (_err) {
+            terminalProxies.delete(ws);
             agentWs.close();
           }
         };
 
         agentWs.onclose = () => {
+          terminalProxies.delete(ws);
           try {
             ws.close();
           } catch (_err) {
             // already closed
           }
-          terminalProxies.delete(ws);
         };
 
         agentWs.onerror = () => {
           log.warn(`ws: terminal proxy error for session=${session} agent=${agentHost}:${agentPort}`);
+          terminalProxies.delete(ws);
           try {
             ws.send("\r\n\x1b[31mFailed to connect to agent terminal server\x1b[0m\r\n");
             ws.close();
@@ -860,10 +879,11 @@ const _server = Bun.serve({
       // Forward terminal data from browser to agent
       const agentWs = terminalProxies.get(ws);
       if (agentWs && agentWs.readyState === WebSocket.OPEN) {
-        if (typeof message === "string") {
-          agentWs.send(message);
-        } else {
-          agentWs.send(message);
+        try {
+          agentWs.send(typeof message === "string" ? message : message);
+        } catch (_err) {
+          terminalProxies.delete(ws);
+          agentWs.close();
         }
       }
     },

--- a/server/src/ssh-manager.ts
+++ b/server/src/ssh-manager.ts
@@ -337,7 +337,13 @@ async function startTunnels(node: RemoteNode, serverPort: number): Promise<NodeC
         connections.delete(node.id);
         updateNodeStatus(node.id, "error", "SSH tunnel disconnected");
         // Auto-reconnect after a delay
-        setTimeout(() => connectNode(node.id), 5000);
+        setTimeout(() => {
+          connectNode(node.id).catch((err) => {
+            log.error(
+              `health: [${node.name}] auto-reconnect failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
+        }, 5000);
       } else {
         log.debug(
           `health: [${node.name}] check failed (tunnel alive): ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Summary

Fixes three interrelated session stability issues:

- **Server crash on remote disconnect**: All agent proxy `fetch()` calls lacked timeouts, causing the server to hang indefinitely when a remote machine disconnects. Added `AbortSignal.timeout(15s)` to all proxy calls, fixed unhandled promise rejection in SSH tunnel auto-reconnect, and cleaned up WebSocket terminal proxy error handling.

- **Session duplication when user delays first message**: When the user waits before sending the first message in a fresh session, both a placeholder and a real session appear in the dashboard. The root cause is the JSONL file birth-time matching failing due to the delay between process start and file creation. Added a CWD-based fallback mapping and prevented placeholder creation when a real session with the same CWD already exists.

- **Zellij session recovery after reboot**: After a machine reboot, zellij resurrects sessions but re-runs only the original pane command (a shell), not the agent command sent via `write-chars`. Now each zellij session gets a wrapper script (`run.sh`) used as the pane command via a generated KDL layout. The script checks for a persisted session-id file and uses `--resume` to continue the original session.

## Test plan

- [x] All 817 tests pass (7 new tests added)
- [x] Biome lint/format clean across all source directories
- [ ] Manual test: connect a remote machine, disconnect it, verify server stays responsive
- [ ] Manual test: launch a session, wait 2+ minutes before first message, verify no duplication
- [ ] Manual test: launch a session in zellij, send a message, reboot, verify session resumes with `--resume`

🤖 Generated with [Claude Code](https://claude.com/claude-code)