### PR TITLE
feat(dashboard): add terminal helpers toolbar with modifier keys and send-keys dialog

### DIFF
--- a/dashboard/src/components/SessionDetail.tsx
+++ b/dashboard/src/components/SessionDetail.tsx
@@ -8,7 +8,8 @@ import { API, STATUS_CONFIG, timeAgo } from "../utils";
 import { DiffModal } from "./DiffModal";
 import { InfoPane } from "./InfoPane";
 import { SendMessage } from "./SendMessage";
-import { TerminalPane } from "./TerminalPane";
+import { TerminalHelpers } from "./TerminalHelpers";
+import { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
 
 type SessionTab = "chat" | "terminal";
 
@@ -144,6 +145,7 @@ export function SessionDetail({
     maxSize: 400,
     side: "bottom",
   });
+  const terminalRef = useRef<TerminalPaneHandle>(null);
 
   const [history, setHistory] = useState<SessionMessage[]>([]);
   const [hasMore, setHasMore] = useState(true);
@@ -656,9 +658,17 @@ export function SessionDetail({
                     Fullscreen
                   </button>
                 )}
+                {hasTerminal && (
+                  <TerminalHelpers
+                    sendData={(data) => terminalRef.current?.sendData(data)}
+                    isConnected={terminalRef.current?.isConnected ?? false}
+                    onFocusTerminal={() => terminalRef.current?.focusTerminal()}
+                  />
+                )}
               </div>
               {hasTerminal && (
                 <TerminalPane
+                  ref={terminalRef}
                   machineId={machineId}
                   sessionName={session.multiplexerSession ?? ""}
                   multiplexer={session.multiplexer ?? "zellij"}

--- a/dashboard/src/components/TerminalHelpers.tsx
+++ b/dashboard/src/components/TerminalHelpers.tsx
@@ -1,0 +1,311 @@
+import type React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { altCode, arrowCode, ctrlCode, ESCAPE, parseKeyCombo, TAB } from "../utils/key-codes";
+
+const HELPERS_STORAGE_KEY = "agentTown:terminalHelpersExpanded";
+const MODIFIER_TIMEOUT_MS = 5000;
+
+type PendingModifier = "ctrl" | "alt" | null;
+
+function loadExpanded(): boolean {
+  try {
+    const stored = localStorage.getItem(HELPERS_STORAGE_KEY);
+    if (stored !== null) return stored === "true";
+  } catch (_err) {
+    // localStorage unavailable
+  }
+  return false;
+}
+
+interface Props {
+  sendData: (data: string) => void;
+  isConnected: boolean;
+  onFocusTerminal: () => void;
+}
+
+export function TerminalHelpers({ sendData, isConnected, onFocusTerminal }: Props): React.JSX.Element {
+  const [expanded, setExpanded] = useState(loadExpanded);
+  const [pendingModifier, setPendingModifier] = useState<PendingModifier>(null);
+  const [showSendKeys, setShowSendKeys] = useState(false);
+  const [sendKeysValue, setSendKeysValue] = useState("");
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sendKeysInputRef = useRef<HTMLInputElement>(null);
+
+  const toggleExpanded = useCallback(() => {
+    setExpanded((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(HELPERS_STORAGE_KEY, String(next));
+      } catch (_err) {
+        // localStorage unavailable
+      }
+      return next;
+    });
+  }, []);
+
+  const clearModifier = useCallback(() => {
+    setPendingModifier(null);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const activateModifier = useCallback(
+    (mod: "ctrl" | "alt") => {
+      clearModifier();
+      setPendingModifier(mod);
+      timeoutRef.current = setTimeout(() => {
+        setPendingModifier(null);
+        timeoutRef.current = null;
+      }, MODIFIER_TIMEOUT_MS);
+    },
+    [clearModifier],
+  );
+
+  // Listen for next keypress when a modifier is pending
+  useEffect(() => {
+    if (!pendingModifier) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Shift" || e.key === "Control" || e.key === "Alt" || e.key === "Meta") return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      let code: string;
+      if (pendingModifier === "ctrl") {
+        code = ctrlCode(e.key);
+      } else {
+        code = altCode(e.key);
+      }
+
+      if (code) {
+        sendData(code);
+      }
+
+      setPendingModifier(null);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+
+      onFocusTerminal();
+    }
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [pendingModifier, sendData, onFocusTerminal]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  function handleDirectSend(data: string) {
+    sendData(data);
+    onFocusTerminal();
+  }
+
+  function handleSendKeysSubmit() {
+    const combo = sendKeysValue.trim();
+    if (!combo) return;
+
+    const code = parseKeyCombo(combo);
+    if (code) {
+      sendData(code);
+    }
+
+    setSendKeysValue("");
+    setShowSendKeys(false);
+    onFocusTerminal();
+  }
+
+  function handleSendKeysKeyDown(e: React.KeyboardEvent) {
+    e.stopPropagation();
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSendKeysSubmit();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setShowSendKeys(false);
+      setSendKeysValue("");
+      onFocusTerminal();
+    }
+  }
+
+  // Focus the send-keys input when it opens
+  useEffect(() => {
+    if (showSendKeys) {
+      sendKeysInputRef.current?.focus();
+    }
+  }, [showSendKeys]);
+
+  return (
+    <div className="terminal-helpers">
+      <button
+        type="button"
+        className={`terminal-helpers-toggle${expanded ? " active" : ""}`}
+        onClick={toggleExpanded}
+        aria-label={expanded ? "Collapse terminal helpers" : "Expand terminal helpers"}
+        title="Terminal helpers"
+      >
+        Helpers
+      </button>
+
+      {expanded && (
+        <div className="terminal-helpers-panel">
+          {/* Modifier keys */}
+          <button
+            type="button"
+            className={`terminal-helper-btn modifier-btn${pendingModifier === "ctrl" ? " active" : ""}`}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => activateModifier("ctrl")}
+            disabled={!isConnected}
+            aria-label="Ctrl modifier — press then type a key"
+            title="Ctrl — click then press a key"
+          >
+            Ctrl
+          </button>
+          <button
+            type="button"
+            className={`terminal-helper-btn modifier-btn${pendingModifier === "alt" ? " active" : ""}`}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => activateModifier("alt")}
+            disabled={!isConnected}
+            aria-label="Alt modifier — press then type a key"
+            title="Alt — click then press a key"
+          >
+            Alt
+          </button>
+
+          <span className="terminal-helpers-separator" />
+
+          {/* Arrow keys */}
+          <button
+            type="button"
+            className="terminal-helper-btn"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => handleDirectSend(arrowCode("up"))}
+            disabled={!isConnected}
+            aria-label="Send arrow up"
+            title="Arrow Up"
+          >
+            ↑
+          </button>
+          <button
+            type="button"
+            className="terminal-helper-btn"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => handleDirectSend(arrowCode("down"))}
+            disabled={!isConnected}
+            aria-label="Send arrow down"
+            title="Arrow Down"
+          >
+            ↓
+          </button>
+          <button
+            type="button"
+            className="terminal-helper-btn"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => handleDirectSend(arrowCode("left"))}
+            disabled={!isConnected}
+            aria-label="Send arrow left"
+            title="Arrow Left"
+          >
+            ←
+          </button>
+          <button
+            type="button"
+            className="terminal-helper-btn"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => handleDirectSend(arrowCode("right"))}
+            disabled={!isConnected}
+            aria-label="Send arrow right"
+            title="Arrow Right"
+          >
+            →
+          </button>
+
+          <span className="terminal-helpers-separator" />
+
+          {/* Special keys */}
+          <button
+            type="button"
+            className="terminal-helper-btn"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => handleDirectSend(TAB)}
+            disabled={!isConnected}
+            aria-label="Send Tab key"
+            title="Tab"
+          >
+            Tab
+          </button>
+          <button
+            type="button"
+            className="terminal-helper-btn"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => handleDirectSend(ESCAPE)}
+            disabled={!isConnected}
+            aria-label="Send Escape key"
+            title="Escape"
+          >
+            Esc
+          </button>
+
+          <span className="terminal-helpers-separator" />
+
+          {/* Send Keys dialog */}
+          <div className="send-keys-wrapper">
+            <button
+              type="button"
+              className={`terminal-helper-btn send-keys-btn${showSendKeys ? " active" : ""}`}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => setShowSendKeys((prev) => !prev)}
+              disabled={!isConnected}
+              aria-label="Open send keys dialog"
+              title="Send custom key combination"
+            >
+              Send Keys
+            </button>
+
+            {showSendKeys && (
+              <div className="send-keys-dialog">
+                <input
+                  ref={sendKeysInputRef}
+                  type="text"
+                  className="send-keys-input"
+                  value={sendKeysValue}
+                  onChange={(e) => setSendKeysValue(e.target.value)}
+                  onKeyDown={handleSendKeysKeyDown}
+                  onClick={(e) => e.stopPropagation()}
+                  placeholder="e.g. Ctrl+C, Alt+B"
+                  aria-label="Key combination to send"
+                />
+                <button
+                  type="button"
+                  className="send-keys-submit"
+                  onClick={handleSendKeysSubmit}
+                  disabled={!sendKeysValue.trim()}
+                  aria-label="Send key combination"
+                >
+                  Send
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {pendingModifier && (
+        <div className="modifier-prompt" aria-live="polite">
+          Press a key for {pendingModifier === "ctrl" ? "Ctrl" : "Alt"}+...
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/TerminalPane.tsx
+++ b/dashboard/src/components/TerminalPane.tsx
@@ -33,19 +33,23 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(function Termi
   const termRef = useRef<Terminal | null>(null);
   const [connected, setConnected] = useState(false);
 
-  useImperativeHandle(ref, () => ({
-    sendData(data: string) {
-      if (wsRef.current?.readyState === WebSocket.OPEN) {
-        wsRef.current.send(data);
-      }
-    },
-    focusTerminal() {
-      termRef.current?.focus();
-    },
-    get isConnected() {
-      return connected;
-    },
-  }), [connected]);
+  useImperativeHandle(
+    ref,
+    () => ({
+      sendData(data: string) {
+        if (wsRef.current?.readyState === WebSocket.OPEN) {
+          wsRef.current.send(data);
+        }
+      },
+      focusTerminal() {
+        termRef.current?.focus();
+      },
+      get isConnected() {
+        return connected;
+      },
+    }),
+    [connected],
+  );
 
   useEffect(() => {
     if (!containerRef.current) return;

--- a/dashboard/src/components/TerminalPane.tsx
+++ b/dashboard/src/components/TerminalPane.tsx
@@ -3,11 +3,17 @@ import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Terminal } from "@xterm/xterm";
 import type React from "react";
-import { useEffect, useRef } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import "@xterm/xterm/css/xterm.css";
 import type { TerminalMultiplexer } from "@agent-town/shared";
 
 const DOUBLE_ESC_THRESHOLD_MS = 500;
+
+export interface TerminalPaneHandle {
+  sendData: (data: string) => void;
+  focusTerminal: () => void;
+  isConnected: boolean;
+}
 
 interface Props {
   machineId: string;
@@ -16,10 +22,30 @@ interface Props {
   onDoubleEsc?: () => void;
 }
 
-export function TerminalPane({ machineId, sessionName, multiplexer, onDoubleEsc }: Props): React.JSX.Element {
+export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(function TerminalPane(
+  { machineId, sessionName, multiplexer, onDoubleEsc },
+  ref,
+): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null);
   const onDoubleEscRef = useRef(onDoubleEsc);
   onDoubleEscRef.current = onDoubleEsc;
+  const wsRef = useRef<WebSocket | null>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const [connected, setConnected] = useState(false);
+
+  useImperativeHandle(ref, () => ({
+    sendData(data: string) {
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        wsRef.current.send(data);
+      }
+    },
+    focusTerminal() {
+      termRef.current?.focus();
+    },
+    get isConnected() {
+      return connected;
+    },
+  }), [connected]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -37,6 +63,8 @@ export function TerminalPane({ machineId, sessionName, multiplexer, onDoubleEsc 
       },
       allowProposedApi: true,
     });
+
+    termRef.current = term;
 
     const fitAddon = new FitAddon();
     const webLinksAddon = new WebLinksAddon();
@@ -66,7 +94,10 @@ export function TerminalPane({ machineId, sessionName, multiplexer, onDoubleEsc 
     const wsUrl = `${protocol}//${window.location.host}/ws/terminal?${params}`;
     const ws = new WebSocket(wsUrl);
     ws.binaryType = "arraybuffer";
+    wsRef.current = ws;
+
     ws.onopen = () => {
+      setConnected(true);
       term.focus();
       // Send a resize after connect to ensure the PTY matches the browser size
       fitAddon.fit();
@@ -88,10 +119,12 @@ export function TerminalPane({ machineId, sessionName, multiplexer, onDoubleEsc 
     };
 
     ws.onclose = () => {
+      setConnected(false);
       term.write("\r\n\x1b[90m--- Connection closed ---\x1b[0m\r\n");
     };
 
     ws.onerror = () => {
+      setConnected(false);
       term.write("\r\n\x1b[31m--- Connection error ---\x1b[0m\r\n");
     };
 
@@ -129,10 +162,13 @@ export function TerminalPane({ machineId, sessionName, multiplexer, onDoubleEsc 
     return () => {
       keyHandler.dispose();
       resizeObserver.disconnect();
+      wsRef.current = null;
+      termRef.current = null;
+      setConnected(false);
       ws.close();
       term.dispose();
     };
   }, [machineId, sessionName, multiplexer]);
 
   return <div className="terminal-pane-container" ref={containerRef} />;
-}
+});

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -1685,6 +1685,163 @@ body {
   flex-shrink: 0;
 }
 
+/* Terminal helpers toolbar */
+.terminal-helpers {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  position: relative;
+}
+
+.terminal-helpers-toggle {
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.terminal-helpers-toggle:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.terminal-helpers-toggle.active {
+  background: var(--accent-bg);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.terminal-helpers-panel {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.terminal-helpers-separator {
+  width: 1px;
+  height: 18px;
+  background: var(--border);
+  margin: 0 2px;
+}
+
+.terminal-helper-btn {
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-family: "Fira Code", "Cascadia Code", "SF Mono", monospace;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+  min-width: 28px;
+  text-align: center;
+}
+
+.terminal-helper-btn:hover:not(:disabled) {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.terminal-helper-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.terminal-helper-btn.active {
+  background: var(--accent-bg);
+  color: var(--accent);
+  border-color: var(--accent);
+  animation: modifier-pulse 1s ease-in-out infinite;
+}
+
+@keyframes modifier-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+.modifier-prompt {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background: var(--bg-primary);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  white-space: nowrap;
+  z-index: 20;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  animation: modifier-pulse 1s ease-in-out infinite;
+}
+
+.send-keys-wrapper {
+  position: relative;
+}
+
+.send-keys-dialog {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px;
+  display: flex;
+  gap: 4px;
+  z-index: 20;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.send-keys-input {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-family: "Fira Code", "Cascadia Code", "SF Mono", monospace;
+  width: 140px;
+  outline: none;
+}
+
+.send-keys-input:focus {
+  border-color: var(--accent);
+}
+
+.send-keys-input::placeholder {
+  color: var(--text-muted);
+}
+
+.send-keys-submit {
+  background: var(--accent-bg);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.send-keys-submit:hover:not(:disabled) {
+  opacity: 0.8;
+}
+
+.send-keys-submit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .terminal-pane-container {
   flex: 1;
   overflow: hidden;

--- a/dashboard/src/utils/key-codes.test.ts
+++ b/dashboard/src/utils/key-codes.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ALT_PREFIX,
+  ENTER,
+  ESCAPE,
+  TAB,
+  altCode,
+  arrowCode,
+  ctrlCode,
+  parseKeyCombo,
+} from "./key-codes";
+
+describe("ctrlCode", () => {
+  test("maps lowercase a-z to control codes", () => {
+    expect(ctrlCode("a")).toBe("\x01");
+    expect(ctrlCode("b")).toBe("\x02");
+    expect(ctrlCode("c")).toBe("\x03");
+    expect(ctrlCode("d")).toBe("\x04");
+    expect(ctrlCode("l")).toBe("\x0c");
+    expect(ctrlCode("z")).toBe("\x1a");
+  });
+
+  test("maps uppercase A-Z to same control codes", () => {
+    expect(ctrlCode("A")).toBe("\x01");
+    expect(ctrlCode("C")).toBe("\x03");
+    expect(ctrlCode("Z")).toBe("\x1a");
+  });
+
+  test("returns empty string for non-letter keys", () => {
+    expect(ctrlCode("1")).toBe("");
+    expect(ctrlCode("")).toBe("");
+    expect(ctrlCode(" ")).toBe("");
+  });
+});
+
+describe("altCode", () => {
+  test("prepends ESC to key", () => {
+    expect(altCode("b")).toBe("\x1bb");
+    expect(altCode("f")).toBe("\x1bf");
+    expect(altCode("d")).toBe("\x1bd");
+  });
+
+  test("handles uppercase", () => {
+    expect(altCode("B")).toBe("\x1bB");
+  });
+
+  test("returns just ESC for empty key", () => {
+    expect(altCode("")).toBe("\x1b");
+  });
+});
+
+describe("arrowCode", () => {
+  test("returns correct ANSI sequences", () => {
+    expect(arrowCode("up")).toBe("\x1b[A");
+    expect(arrowCode("down")).toBe("\x1b[B");
+    expect(arrowCode("right")).toBe("\x1b[C");
+    expect(arrowCode("left")).toBe("\x1b[D");
+  });
+});
+
+describe("parseKeyCombo", () => {
+  test("parses Ctrl+letter combos", () => {
+    expect(parseKeyCombo("Ctrl+C")).toBe("\x03");
+    expect(parseKeyCombo("Ctrl+c")).toBe("\x03");
+    expect(parseKeyCombo("Ctrl+B")).toBe("\x02");
+    expect(parseKeyCombo("Ctrl+Z")).toBe("\x1a");
+  });
+
+  test("parses Alt+letter combos", () => {
+    expect(parseKeyCombo("Alt+B")).toBe("\x1bb");
+    expect(parseKeyCombo("Alt+f")).toBe("\x1bf");
+  });
+
+  test("parses standalone special keys", () => {
+    expect(parseKeyCombo("Escape")).toBe("\x1b");
+    expect(parseKeyCombo("Tab")).toBe("\x09");
+    expect(parseKeyCombo("Enter")).toBe("\r");
+  });
+
+  test("parses arrow keys", () => {
+    expect(parseKeyCombo("Up")).toBe("\x1b[A");
+    expect(parseKeyCombo("Down")).toBe("\x1b[B");
+    expect(parseKeyCombo("Left")).toBe("\x1b[D");
+    expect(parseKeyCombo("Right")).toBe("\x1b[C");
+  });
+
+  test("is case-insensitive for modifiers", () => {
+    expect(parseKeyCombo("ctrl+c")).toBe("\x03");
+    expect(parseKeyCombo("CTRL+C")).toBe("\x03");
+    expect(parseKeyCombo("alt+b")).toBe("\x1bb");
+  });
+
+  test("handles Ctrl+Shift combos by uppercasing", () => {
+    expect(parseKeyCombo("Ctrl+Shift+C")).toBe("\x03");
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(parseKeyCombo("")).toBe("");
+  });
+
+  test("returns empty string for unknown keys", () => {
+    expect(parseKeyCombo("SuperSpecialKey")).toBe("");
+  });
+
+  test("handles function keys with Ctrl", () => {
+    expect(parseKeyCombo("Ctrl+A")).toBe("\x01");
+  });
+});
+
+describe("constants", () => {
+  test("TAB is correct", () => {
+    expect(TAB).toBe("\x09");
+  });
+
+  test("ESCAPE is correct", () => {
+    expect(ESCAPE).toBe("\x1b");
+  });
+
+  test("ENTER is correct", () => {
+    expect(ENTER).toBe("\r");
+  });
+
+  test("ALT_PREFIX is ESC", () => {
+    expect(ALT_PREFIX).toBe("\x1b");
+  });
+});

--- a/dashboard/src/utils/key-codes.test.ts
+++ b/dashboard/src/utils/key-codes.test.ts
@@ -1,14 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import {
-  ALT_PREFIX,
-  ENTER,
-  ESCAPE,
-  TAB,
-  altCode,
-  arrowCode,
-  ctrlCode,
-  parseKeyCombo,
-} from "./key-codes";
+import { ALT_PREFIX, altCode, arrowCode, ctrlCode, ENTER, ESCAPE, parseKeyCombo, TAB } from "./key-codes";
 
 describe("ctrlCode", () => {
   test("maps lowercase a-z to control codes", () => {

--- a/dashboard/src/utils/key-codes.ts
+++ b/dashboard/src/utils/key-codes.ts
@@ -1,0 +1,86 @@
+export const TAB = "\x09";
+export const ESCAPE = "\x1b";
+export const ENTER = "\r";
+export const ALT_PREFIX = "\x1b";
+
+const ARROW_CODES: Record<string, string> = {
+  up: "\x1b[A",
+  down: "\x1b[B",
+  right: "\x1b[C",
+  left: "\x1b[D",
+};
+
+const SPECIAL_KEYS: Record<string, string> = {
+  escape: ESCAPE,
+  tab: TAB,
+  enter: ENTER,
+  up: ARROW_CODES.up,
+  down: ARROW_CODES.down,
+  left: ARROW_CODES.left,
+  right: ARROW_CODES.right,
+};
+
+export function ctrlCode(key: string): string {
+  if (key.length !== 1) return "";
+  const lower = key.toLowerCase();
+  const code = lower.charCodeAt(0);
+  if (code < 97 || code > 122) return "";
+  return String.fromCharCode(code - 96);
+}
+
+export function altCode(key: string): string {
+  return ALT_PREFIX + key;
+}
+
+export function arrowCode(direction: "up" | "down" | "left" | "right"): string {
+  return ARROW_CODES[direction];
+}
+
+export function parseKeyCombo(combo: string): string {
+  if (!combo) return "";
+
+  const lower = combo.toLowerCase().trim();
+
+  if (SPECIAL_KEYS[lower]) {
+    return SPECIAL_KEYS[lower];
+  }
+
+  const parts = combo.split("+").map((p) => p.trim());
+
+  const modifiers = new Set<string>();
+  let key = "";
+
+  for (const part of parts) {
+    const lowerPart = part.toLowerCase();
+    if (lowerPart === "ctrl" || lowerPart === "alt" || lowerPart === "shift") {
+      modifiers.add(lowerPart);
+    } else {
+      key = part;
+    }
+  }
+
+  if (!key) return "";
+
+  const keyLower = key.toLowerCase();
+
+  if (SPECIAL_KEYS[keyLower]) {
+    if (modifiers.has("ctrl")) {
+      return ctrlCode(keyLower) || SPECIAL_KEYS[keyLower];
+    }
+    if (modifiers.has("alt")) {
+      return altCode(SPECIAL_KEYS[keyLower]);
+    }
+    return SPECIAL_KEYS[keyLower];
+  }
+
+  if (modifiers.has("ctrl")) {
+    const result = ctrlCode(key);
+    if (result) return result;
+  }
+
+  if (modifiers.has("alt")) {
+    return altCode(key.toLowerCase());
+  }
+
+  return "";
+}


### PR DESCRIPTION
## Summary
- Add expandable "Helpers" toolbar to the terminal tab with modifier key buttons (Ctrl, Alt), arrow keys (Up/Down/Left/Right), Tab, Escape, and a custom send-keys dialog
- Expose TerminalPane WebSocket via `useImperativeHandle` ref for direct key injection
- New key-code utility module for converting key names to terminal escape sequences
- Ctrl/Alt buttons enter a "waiting for next key" state — user clicks Ctrl, then presses any key to send the combination
- Send Keys dialog allows typing arbitrary combos like "Ctrl+C" or "Alt+B"
- All buttons prevent focus steal from the terminal

## Changes
- `dashboard/src/components/TerminalPane.tsx` — `forwardRef` + `useImperativeHandle` exposing `sendData`, `focusTerminal`, `isConnected`
- `dashboard/src/utils/key-codes.ts` — Utility for Ctrl codes, Alt codes, arrow sequences, key combo parsing
- `dashboard/src/components/TerminalHelpers.tsx` — New component: expandable helpers toolbar
- `dashboard/src/components/SessionDetail.tsx` — Integrate TerminalHelpers in terminal tab toolbar
- `dashboard/src/styles.css` — Styles for helpers panel, buttons, modifier prompt, send-keys dialog

## Test Plan
- [x] 20 key-code utility tests (ctrlCode, altCode, arrowCode, parseKeyCombo, constants)
- [x] All 928 tests pass (908 existing + 20 new)
- [x] Biome lint clean
- [ ] Manual verification: helpers expand/collapse, modifier key combos, direct key sends, send-keys dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)