### PR TITLE
feat(agent,server,dashboard): add drag-and-drop file attachment with upload to agent

### DIFF
--- a/agent/src/file-upload.test.ts
+++ b/agent/src/file-upload.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { MAX_UPLOAD_SIZE_BYTES, UPLOAD_DIR, cleanupOldUploads, sanitizeFilename } from "./file-upload";
+import { cleanupOldUploads, MAX_UPLOAD_SIZE_BYTES, sanitizeFilename, UPLOAD_DIR } from "./file-upload";
 
 describe("sanitizeFilename", () => {
   test("strips path separators", () => {

--- a/agent/src/file-upload.test.ts
+++ b/agent/src/file-upload.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { MAX_UPLOAD_SIZE_BYTES, UPLOAD_DIR, cleanupOldUploads, sanitizeFilename } from "./file-upload";
+
+describe("sanitizeFilename", () => {
+  test("strips path separators", () => {
+    const result = sanitizeFilename("../../etc/passwd");
+    expect(result).not.toContain("/");
+    expect(result).not.toContain("..");
+    expect(result).toContain("passwd");
+  });
+
+  test("strips backslash path separators", () => {
+    const result = sanitizeFilename("C:\\Users\\file.txt");
+    expect(result).not.toContain("\\");
+    expect(result).toContain("file.txt");
+  });
+
+  test("removes special characters but keeps alphanumeric, dots, hyphens, underscores", () => {
+    const result = sanitizeFilename("my file (1).png");
+    expect(result).toMatch(/^[a-f0-9-]+-my_file_1.png$/);
+  });
+
+  test("prepends UUID", () => {
+    const result = sanitizeFilename("photo.png");
+    expect(result).toMatch(/^[a-f0-9-]{36}-photo.png$/);
+  });
+
+  test("handles empty string", () => {
+    const result = sanitizeFilename("");
+    expect(result).toMatch(/^[a-f0-9-]{36}-upload$/);
+  });
+
+  test("handles filename with only special chars", () => {
+    const result = sanitizeFilename("@#$%^&*");
+    expect(result).toMatch(/^[a-f0-9-]{36}-upload$/);
+  });
+
+  test("preserves file extension", () => {
+    const result = sanitizeFilename("document.pdf");
+    expect(result).toEndWith("-document.pdf");
+  });
+
+  test("handles multiple dots in filename", () => {
+    const result = sanitizeFilename("my.file.name.tar.gz");
+    expect(result).toEndWith("-my.file.name.tar.gz");
+  });
+});
+
+describe("MAX_UPLOAD_SIZE_BYTES", () => {
+  test("defaults to 50MB", () => {
+    expect(MAX_UPLOAD_SIZE_BYTES).toBe(50 * 1024 * 1024);
+  });
+});
+
+describe("UPLOAD_DIR", () => {
+  test("points to /tmp/agent-town-uploads", () => {
+    expect(UPLOAD_DIR).toBe("/tmp/agent-town-uploads");
+  });
+});
+
+describe("cleanupOldUploads", () => {
+  const testDir = "/tmp/agent-town-uploads-test";
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("removes files older than maxAge", async () => {
+    const filePath = join(testDir, "old-file.txt");
+    writeFileSync(filePath, "old content");
+
+    // Set mtime to 2 hours ago
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    const { utimesSync } = await import("node:fs");
+    utimesSync(filePath, twoHoursAgo, twoHoursAgo);
+
+    const removed = await cleanupOldUploads(60 * 60 * 1000, testDir);
+    expect(removed).toBe(1);
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  test("keeps recent files", async () => {
+    const filePath = join(testDir, "recent-file.txt");
+    writeFileSync(filePath, "recent content");
+
+    const removed = await cleanupOldUploads(60 * 60 * 1000, testDir);
+    expect(removed).toBe(0);
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  test("returns 0 when directory does not exist", async () => {
+    const removed = await cleanupOldUploads(60 * 60 * 1000, "/tmp/nonexistent-cleanup-test");
+    expect(removed).toBe(0);
+  });
+});

--- a/agent/src/file-upload.ts
+++ b/agent/src/file-upload.ts
@@ -1,0 +1,56 @@
+import { readdirSync, statSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+export const UPLOAD_DIR = "/tmp/agent-town-uploads";
+
+const envMaxMB = process.env.MAX_UPLOAD_SIZE_MB;
+export const MAX_UPLOAD_SIZE_BYTES = (envMaxMB ? parseInt(envMaxMB, 10) : 50) * 1024 * 1024;
+
+export function sanitizeFilename(name: string): string {
+  let sanitized = name.replace(/[/\\]/g, "_");
+
+  const lastSep = Math.max(sanitized.lastIndexOf("/"), sanitized.lastIndexOf("\\"));
+  if (lastSep >= 0) {
+    sanitized = sanitized.slice(lastSep + 1);
+  }
+
+  sanitized = sanitized.replace(/[^a-zA-Z0-9._-]/g, "_");
+
+  sanitized = sanitized.replace(/\.{2,}/g, "").replace(/^\.+/, "");
+
+  sanitized = sanitized.replace(/_+/g, "_").replace(/^_+|_+$/g, "").replace(/_\./g, ".");
+
+  if (!sanitized) {
+    sanitized = "upload";
+  }
+
+  const uuid = crypto.randomUUID();
+  return `${uuid}-${sanitized}`;
+}
+
+export async function cleanupOldUploads(maxAgeMs: number, dir: string = UPLOAD_DIR): Promise<number> {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch (_err) {
+    return 0;
+  }
+
+  const now = Date.now();
+  let removed = 0;
+
+  for (const entry of entries) {
+    const filePath = join(dir, entry);
+    try {
+      const stat = statSync(filePath);
+      if (stat.isFile() && now - stat.mtimeMs > maxAgeMs) {
+        unlinkSync(filePath);
+        removed++;
+      }
+    } catch (_err) {
+      // skip files we can't stat or delete
+    }
+  }
+
+  return removed;
+}

--- a/agent/src/file-upload.ts
+++ b/agent/src/file-upload.ts
@@ -18,7 +18,10 @@ export function sanitizeFilename(name: string): string {
 
   sanitized = sanitized.replace(/\.{2,}/g, "").replace(/^\.+/, "");
 
-  sanitized = sanitized.replace(/_+/g, "_").replace(/^_+|_+$/g, "").replace(/_\./g, ".");
+  sanitized = sanitized
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_\./g, ".");
 
   if (!sanitized) {
     sanitized = "upload";

--- a/agent/src/terminal-server.ts
+++ b/agent/src/terminal-server.ts
@@ -1045,7 +1045,9 @@ export function startTerminalServer(port: number, machineId: string): Server {
 
           if (file.size > MAX_UPLOAD_SIZE_BYTES) {
             return Response.json(
-              { error: `File too large (${Math.round(file.size / 1024 / 1024)}MB). Max: ${Math.round(MAX_UPLOAD_SIZE_BYTES / 1024 / 1024)}MB` },
+              {
+                error: `File too large (${Math.round(file.size / 1024 / 1024)}MB). Max: ${Math.round(MAX_UPLOAD_SIZE_BYTES / 1024 / 1024)}MB`,
+              },
               { status: 413 },
             );
           }

--- a/agent/src/terminal-server.ts
+++ b/agent/src/terminal-server.ts
@@ -1029,6 +1029,48 @@ export function startTerminalServer(port: number, machineId: string): Server {
         }
       }
 
+      // HTTP endpoint: upload a file to the agent machine
+      if (url.pathname === "/api/upload" && req.method === "POST") {
+        try {
+          const { mkdirSync, writeFileSync } = await import("node:fs");
+          const { join } = await import("node:path");
+          const { UPLOAD_DIR, MAX_UPLOAD_SIZE_BYTES, sanitizeFilename } = await import("./file-upload");
+
+          const formData = await req.formData();
+          const file = formData.get("file");
+
+          if (!file || !(file instanceof File)) {
+            return Response.json({ error: "No file provided" }, { status: 400 });
+          }
+
+          if (file.size > MAX_UPLOAD_SIZE_BYTES) {
+            return Response.json(
+              { error: `File too large (${Math.round(file.size / 1024 / 1024)}MB). Max: ${Math.round(MAX_UPLOAD_SIZE_BYTES / 1024 / 1024)}MB` },
+              { status: 413 },
+            );
+          }
+
+          mkdirSync(UPLOAD_DIR, { recursive: true });
+
+          const safeName = sanitizeFilename(file.name);
+          const filePath = join(UPLOAD_DIR, safeName);
+
+          const buffer = await file.arrayBuffer();
+          writeFileSync(filePath, Buffer.from(buffer));
+
+          log.info(`upload: saved ${file.name} (${file.size} bytes) as ${safeName}`);
+
+          return Response.json({
+            ok: true,
+            path: filePath,
+            filename: file.name,
+          });
+        } catch (err) {
+          log.error(`upload failed: ${err instanceof Error ? err.message : "unknown"}`);
+          return Response.json({ error: "Upload failed" }, { status: 500 });
+        }
+      }
+
       // HTTP endpoint: send text to a multiplexer session
       //
       // Uses PTY attachment with bracketed paste mode for reliable text delivery

--- a/dashboard/src/components/FileDropZone.tsx
+++ b/dashboard/src/components/FileDropZone.tsx
@@ -1,0 +1,126 @@
+import type React from "react";
+import { useCallback, useRef, useState } from "react";
+import { formatFileRef, getFileRefPrefix, uploadFile } from "../utils/file-upload";
+
+const ERROR_DISMISS_MS = 5000;
+
+interface Props {
+  machineId: string;
+  onFileUploaded: (ref: string) => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+}
+
+export function FileDropZone({ machineId, onFileUploaded, disabled, children }: Props): React.JSX.Element {
+  const [isDragging, setIsDragging] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState("");
+  const [error, setError] = useState("");
+  const dragCounterRef = useRef(0);
+  const errorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showError = useCallback((msg: string) => {
+    setError(msg);
+    if (errorTimeoutRef.current) {
+      clearTimeout(errorTimeoutRef.current);
+    }
+    errorTimeoutRef.current = setTimeout(() => {
+      setError("");
+      errorTimeoutRef.current = null;
+    }, ERROR_DISMISS_MS);
+  }, []);
+
+  function handleDragEnter(e: React.DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (disabled) return;
+    dragCounterRef.current++;
+    if (e.dataTransfer.types.includes("Files")) {
+      setIsDragging(true);
+    }
+  }
+
+  function handleDragLeave(e: React.DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current--;
+    if (dragCounterRef.current <= 0) {
+      dragCounterRef.current = 0;
+      setIsDragging(false);
+    }
+  }
+
+  function handleDragOver(e: React.DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  async function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+    dragCounterRef.current = 0;
+
+    if (disabled || uploading) return;
+
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length === 0) return;
+
+    setUploading(true);
+    const refs: string[] = [];
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      setUploadProgress(`Uploading ${file.name}${files.length > 1 ? ` (${i + 1}/${files.length})` : ""}...`);
+
+      try {
+        const result = await uploadFile(machineId, file);
+        const prefix = getFileRefPrefix(file.type);
+        refs.push(formatFileRef(prefix, result.path));
+      } catch (err) {
+        showError(err instanceof Error ? err.message : `Failed to upload ${file.name}`);
+      }
+    }
+
+    setUploading(false);
+    setUploadProgress("");
+
+    if (refs.length > 0) {
+      onFileUploaded(refs.join("\n"));
+    }
+  }
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop zone requires event handlers
+    <div
+      className="file-drop-zone"
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
+      {children}
+
+      {isDragging && (
+        <div className="file-drop-overlay" role="status">
+          <div className="file-drop-overlay-content">
+            <span className="file-drop-icon">📁</span>
+            <span className="file-drop-text">Drop files here</span>
+          </div>
+        </div>
+      )}
+
+      {uploading && uploadProgress && (
+        <div className="file-upload-progress" aria-live="polite">
+          {uploadProgress}
+        </div>
+      )}
+
+      {error && (
+        <div className="file-upload-error" aria-live="assertive">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/SendMessage.tsx
+++ b/dashboard/src/components/SendMessage.tsx
@@ -1,7 +1,11 @@
 import type { AgentType } from "@agent-town/shared";
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { API } from "../utils";
+
+export interface SendMessageHandle {
+  appendText: (text: string) => void;
+}
 
 interface Props {
   machineId: string;
@@ -11,24 +15,38 @@ interface Props {
   onSent?: () => void;
 }
 
-export function SendMessage({ machineId, multiplexer, session, agentType, onSent }: Props): React.JSX.Element {
+export const SendMessage = forwardRef<SendMessageHandle, Props>(function SendMessage(
+  { machineId, multiplexer, session, agentType, onSent },
+  ref,
+): React.JSX.Element {
   const [text, setText] = useState("");
   const [sending, setSending] = useState(false);
   const [error, setError] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  useImperativeHandle(ref, () => ({
+    appendText(newText: string) {
+      setText((prev) => {
+        const separator = prev && !prev.endsWith("\n") ? "\n" : "";
+        return prev + separator + newText;
+      });
+      setTimeout(() => textareaRef.current?.focus(), 0);
+    },
+  }));
+
   useEffect(() => {
     textareaRef.current?.focus();
   }, []);
 
-  // Auto-resize textarea
+  // Auto-resize textarea when content changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: text is an intentional trigger for resize
   useEffect(() => {
     const el = textareaRef.current;
     if (el) {
       el.style.height = "auto";
       el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
     }
-  }, []);
+  }, [text]);
 
   async function handleSend() {
     if (!text.trim() || sending) return;
@@ -105,4 +123,4 @@ export function SendMessage({ machineId, multiplexer, session, agentType, onSent
       </div>
     </div>
   );
-}
+});

--- a/dashboard/src/components/SessionDetail.tsx
+++ b/dashboard/src/components/SessionDetail.tsx
@@ -6,8 +6,9 @@ import { useResizable } from "../hooks/useResizable";
 import { useWindowWidth } from "../hooks/useWindowWidth";
 import { API, STATUS_CONFIG, timeAgo } from "../utils";
 import { DiffModal } from "./DiffModal";
+import { FileDropZone } from "./FileDropZone";
 import { InfoPane } from "./InfoPane";
-import { SendMessage } from "./SendMessage";
+import { SendMessage, type SendMessageHandle } from "./SendMessage";
 import { TerminalPane } from "./TerminalPane";
 
 type SessionTab = "chat" | "terminal";
@@ -164,6 +165,7 @@ export function SessionDetail({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messageContainerRef = useRef<HTMLDivElement>(null);
   const prevMessageRef = useRef(session.lastMessage);
+  const sendMessageRef = useRef<SendMessageHandle>(null);
 
   // Tick for live timestamp updates
   useEffect(() => {
@@ -511,162 +513,169 @@ export function SessionDetail({
       </div>
 
       <div className={`fullscreen-body${infoPaneResize.isDragging || inputResize.isDragging ? " resizing" : ""}`}>
-        <div className="fullscreen-main">
-          {activeTab === "chat" ? (
-            <>
-              <div className={`fullscreen-messages ${flash ? "flash" : ""}`} ref={messageContainerRef}>
-                {hasMore && (
-                  <div className="chat-controls">
-                    <button
-                      type="button"
-                      className="load-previous-btn"
-                      onClick={loadPrevious}
-                      disabled={loadingHistory}
-                    >
-                      {loadingHistory ? "Loading..." : "Load previous messages"}
-                    </button>
-                    <button
-                      type="button"
-                      className="load-previous-btn load-all-btn"
-                      onClick={loadAll}
-                      disabled={loadingHistory}
-                    >
-                      Load all
-                    </button>
-                  </div>
-                )}
-
-                {history
-                  .filter((msg) => showToolDetails || !isToolResultMessage(msg))
-                  .map((msg) => (
-                    <div
-                      key={`${msg.timestamp}-${msg.role}-${msg.content?.slice(0, 20) ?? ""}`}
-                      className={`chat-message chat-${msg.role}`}
-                    >
-                      <div className="chat-message-header">
-                        <span className="chat-role">{msg.role === "user" ? "You" : "Assistant"}</span>
-                        <span className="chat-timestamp">{new Date(msg.timestamp).toLocaleString()}</span>
-                        {msg.model && <span className="chat-model">{msg.model}</span>}
-                      </div>
-                      <div className="chat-message-body">
-                        {msg.thinking && showThinking && (
-                          <details className="thinking-block" open>
-                            <summary>Thinking...</summary>
-                            <div className="thinking-content">{msg.thinking}</div>
-                          </details>
-                        )}
-                        {msg.role === "assistant" ? (
-                          <>
-                            {msg.content.trim() ? (
-                              <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
-                                {msg.content}
-                              </Markdown>
-                            ) : isToolOnlyMessage(msg) && !showToolDetails ? (
-                              <div className="chat-tools-summary">
-                                Used{" "}
-                                {msg.toolUse?.map((t) => (
-                                  <span key={t.id} className="tool-badge">
-                                    {t.name}
-                                  </span>
-                                ))}
-                              </div>
-                            ) : msg.toolUse?.length && showToolDetails ? null : !msg.thinking ? (
-                              <span className="chat-empty-hint">[No text content]</span>
-                            ) : null}
-                            {msg.toolUse && msg.toolUse.length > 0 && showToolDetails && (
-                              <div className="chat-tool-calls">
-                                {msg.toolUse.map((t) => (
-                                  <ToolCallBlock key={t.id} tool={t} toolResults={msg.toolResults} />
-                                ))}
-                              </div>
-                            )}
-                            {msg.toolUse && msg.toolUse.length > 0 && !showToolDetails && msg.content.trim() && (
-                              <div className="chat-tools">
-                                {msg.toolUse.map((t) => (
-                                  <span key={t.id} className="tool-badge">
-                                    {t.name}
-                                  </span>
-                                ))}
-                              </div>
-                            )}
-                          </>
-                        ) : (
-                          <div className="chat-user-text">
-                            {msg.content.trim()
-                              ? msg.content
-                              : showToolDetails && msg.toolResults?.length
-                                ? msg.toolResults.map((tr) => (
-                                    <div key={tr.toolUseId} className="tool-call-result">
-                                      <div className="tool-call-label">Result ({tr.toolUseId})</div>
-                                      <pre>{tr.content}</pre>
-                                    </div>
-                                  ))
-                                : msg.content || "[tool result]"}
-                          </div>
-                        )}
-                      </div>
+        <FileDropZone
+          machineId={machineId}
+          onFileUploaded={(ref) => sendMessageRef.current?.appendText(ref)}
+          disabled={!hasTerminal}
+        >
+          <div className="fullscreen-main">
+            {activeTab === "chat" ? (
+              <>
+                <div className={`fullscreen-messages ${flash ? "flash" : ""}`} ref={messageContainerRef}>
+                  {hasMore && (
+                    <div className="chat-controls">
+                      <button
+                        type="button"
+                        className="load-previous-btn"
+                        onClick={loadPrevious}
+                        disabled={loadingHistory}
+                      >
+                        {loadingHistory ? "Loading..." : "Load previous messages"}
+                      </button>
+                      <button
+                        type="button"
+                        className="load-previous-btn load-all-btn"
+                        onClick={loadAll}
+                        disabled={loadingHistory}
+                      >
+                        Load all
+                      </button>
                     </div>
-                  ))}
+                  )}
 
-                {history.length === 0 && !loadingHistory && (
-                  <div className="no-sessions" style={{ padding: "40px 0" }}>
-                    No messages yet
-                  </div>
-                )}
+                  {history
+                    .filter((msg) => showToolDetails || !isToolResultMessage(msg))
+                    .map((msg) => (
+                      <div
+                        key={`${msg.timestamp}-${msg.role}-${msg.content?.slice(0, 20) ?? ""}`}
+                        className={`chat-message chat-${msg.role}`}
+                      >
+                        <div className="chat-message-header">
+                          <span className="chat-role">{msg.role === "user" ? "You" : "Assistant"}</span>
+                          <span className="chat-timestamp">{new Date(msg.timestamp).toLocaleString()}</span>
+                          {msg.model && <span className="chat-model">{msg.model}</span>}
+                        </div>
+                        <div className="chat-message-body">
+                          {msg.thinking && showThinking && (
+                            <details className="thinking-block" open>
+                              <summary>Thinking...</summary>
+                              <div className="thinking-content">{msg.thinking}</div>
+                            </details>
+                          )}
+                          {msg.role === "assistant" ? (
+                            <>
+                              {msg.content.trim() ? (
+                                <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                                  {msg.content}
+                                </Markdown>
+                              ) : isToolOnlyMessage(msg) && !showToolDetails ? (
+                                <div className="chat-tools-summary">
+                                  Used{" "}
+                                  {msg.toolUse?.map((t) => (
+                                    <span key={t.id} className="tool-badge">
+                                      {t.name}
+                                    </span>
+                                  ))}
+                                </div>
+                              ) : msg.toolUse?.length && showToolDetails ? null : !msg.thinking ? (
+                                <span className="chat-empty-hint">[No text content]</span>
+                              ) : null}
+                              {msg.toolUse && msg.toolUse.length > 0 && showToolDetails && (
+                                <div className="chat-tool-calls">
+                                  {msg.toolUse.map((t) => (
+                                    <ToolCallBlock key={t.id} tool={t} toolResults={msg.toolResults} />
+                                  ))}
+                                </div>
+                              )}
+                              {msg.toolUse && msg.toolUse.length > 0 && !showToolDetails && msg.content.trim() && (
+                                <div className="chat-tools">
+                                  {msg.toolUse.map((t) => (
+                                    <span key={t.id} className="tool-badge">
+                                      {t.name}
+                                    </span>
+                                  ))}
+                                </div>
+                              )}
+                            </>
+                          ) : (
+                            <div className="chat-user-text">
+                              {msg.content.trim()
+                                ? msg.content
+                                : showToolDetails && msg.toolResults?.length
+                                  ? msg.toolResults.map((tr) => (
+                                      <div key={tr.toolUseId} className="tool-call-result">
+                                        <div className="tool-call-label">Result ({tr.toolUseId})</div>
+                                        <pre>{tr.content}</pre>
+                                      </div>
+                                    ))
+                                  : msg.content || "[tool result]"}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    ))}
 
-                <div ref={messagesEndRef} />
-              </div>
+                  {history.length === 0 && !loadingHistory && (
+                    <div className="no-sessions" style={{ padding: "40px 0" }}>
+                      No messages yet
+                    </div>
+                  )}
 
-              {showInlineActions && <div className="fullscreen-actions">{actionButtons}</div>}
+                  <div ref={messagesEndRef} />
+                </div>
 
-              {hasTerminal && (
-                <>
-                  {/* biome-ignore lint/a11y/noStaticElementInteractions: resize handle requires mouse interaction */}
-                  <div
-                    className={`resize-handle resize-handle-vertical${inputResize.isDragging ? " active" : ""}`}
-                    onMouseDown={inputResize.handleMouseDown}
-                    onDoubleClick={inputResize.resetSize}
-                    title="Drag to resize, double-click to reset"
-                  />
-                  <div className="fullscreen-input" style={{ height: inputResize.size }}>
-                    <SendMessage
-                      machineId={machineId}
-                      multiplexer={session.multiplexer ?? "zellij"}
-                      session={session.multiplexerSession ?? ""}
-                      agentType={session.agentType}
-                      onSent={handleSent}
+                {showInlineActions && <div className="fullscreen-actions">{actionButtons}</div>}
+
+                {hasTerminal && (
+                  <>
+                    {/* biome-ignore lint/a11y/noStaticElementInteractions: resize handle requires mouse interaction */}
+                    <div
+                      className={`resize-handle resize-handle-vertical${inputResize.isDragging ? " active" : ""}`}
+                      onMouseDown={inputResize.handleMouseDown}
+                      onDoubleClick={inputResize.resetSize}
+                      title="Drag to resize, double-click to reset"
                     />
-                  </div>
-                </>
-              )}
-            </>
-          ) : (
-            <div className="terminal-tab-content">
-              <div className="terminal-tab-toolbar">
-                {onOpenTerminalFullscreen && hasTerminal && (
-                  <button
-                    type="button"
-                    className="action-btn terminal-btn"
-                    onClick={() => {
-                      setActiveTab("chat");
-                      onOpenTerminalFullscreen(session.multiplexerSession ?? "", session.multiplexer ?? "zellij");
-                    }}
-                    aria-label="Open terminal in fullscreen"
-                  >
-                    Fullscreen
-                  </button>
+                    <div className="fullscreen-input" style={{ height: inputResize.size }}>
+                      <SendMessage
+                        ref={sendMessageRef}
+                        machineId={machineId}
+                        multiplexer={session.multiplexer ?? "zellij"}
+                        session={session.multiplexerSession ?? ""}
+                        agentType={session.agentType}
+                        onSent={handleSent}
+                      />
+                    </div>
+                  </>
+                )}
+              </>
+            ) : (
+              <div className="terminal-tab-content">
+                <div className="terminal-tab-toolbar">
+                  {onOpenTerminalFullscreen && hasTerminal && (
+                    <button
+                      type="button"
+                      className="action-btn terminal-btn"
+                      onClick={() => {
+                        setActiveTab("chat");
+                        onOpenTerminalFullscreen(session.multiplexerSession ?? "", session.multiplexer ?? "zellij");
+                      }}
+                      aria-label="Open terminal in fullscreen"
+                    >
+                      Fullscreen
+                    </button>
+                  )}
+                </div>
+                {hasTerminal && (
+                  <TerminalPane
+                    machineId={machineId}
+                    sessionName={session.multiplexerSession ?? ""}
+                    multiplexer={session.multiplexer ?? "zellij"}
+                  />
                 )}
               </div>
-              {hasTerminal && (
-                <TerminalPane
-                  machineId={machineId}
-                  sessionName={session.multiplexerSession ?? ""}
-                  multiplexer={session.multiplexer ?? "zellij"}
-                />
-              )}
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+        </FileDropZone>
 
         {isWide && infoPaneVisible && (
           /* biome-ignore lint/a11y/noStaticElementInteractions: resize handle requires mouse interaction */

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -4468,3 +4468,71 @@ body {
     border-bottom: 1px solid var(--border);
   }
 }
+
+/* File drop zone */
+.file-drop-zone {
+  position: relative;
+  display: contents;
+}
+
+.file-drop-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(59, 130, 246, 0.08);
+  border: 2px dashed var(--accent);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 30;
+  pointer-events: none;
+}
+
+.file-drop-overlay-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  color: var(--accent);
+}
+
+.file-drop-icon {
+  font-size: 32px;
+}
+
+.file-drop-text {
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.file-upload-progress {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-primary);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  padding: 6px 16px;
+  font-size: 12px;
+  z-index: 25;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  white-space: nowrap;
+}
+
+.file-upload-error {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-primary);
+  color: var(--error, #ef4444);
+  border: 1px solid var(--error, #ef4444);
+  border-radius: 6px;
+  padding: 6px 16px;
+  font-size: 12px;
+  z-index: 25;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  white-space: nowrap;
+}

--- a/dashboard/src/utils.test.ts
+++ b/dashboard/src/utils.test.ts
@@ -244,7 +244,7 @@ describe("API", () => {
     }
   });
 
-  test("contains exactly 15 endpoints", () => {
-    expect(Object.keys(API)).toHaveLength(15);
+  test("contains exactly 16 endpoints", () => {
+    expect(Object.keys(API)).toHaveLength(16);
   });
 });

--- a/dashboard/src/utils.ts
+++ b/dashboard/src/utils.ts
@@ -58,6 +58,7 @@ export const API = {
   SESSIONS_KILL: "/api/sessions/kill",
   SESSIONS_DELETE: "/api/sessions/delete",
   SESSIONS_SEND: "/api/sessions/send",
+  SESSIONS_UPLOAD: "/api/sessions/upload",
   AGENTS_LAUNCH: "/api/agents/launch",
   AGENTS_RESUME: "/api/agents/resume",
   SESSIONS_RECONNECT: "/api/sessions/reconnect",

--- a/dashboard/src/utils/file-upload.test.ts
+++ b/dashboard/src/utils/file-upload.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { formatFileRef, getFileRefPrefix } from "./file-upload";
+
+describe("getFileRefPrefix", () => {
+  test("returns 'image' for image MIME types", () => {
+    expect(getFileRefPrefix("image/png")).toBe("image");
+    expect(getFileRefPrefix("image/jpeg")).toBe("image");
+    expect(getFileRefPrefix("image/gif")).toBe("image");
+    expect(getFileRefPrefix("image/webp")).toBe("image");
+    expect(getFileRefPrefix("image/svg+xml")).toBe("image");
+  });
+
+  test("returns 'file' for non-image types", () => {
+    expect(getFileRefPrefix("application/pdf")).toBe("file");
+    expect(getFileRefPrefix("text/plain")).toBe("file");
+    expect(getFileRefPrefix("application/json")).toBe("file");
+    expect(getFileRefPrefix("video/mp4")).toBe("file");
+  });
+
+  test("returns 'file' for empty type", () => {
+    expect(getFileRefPrefix("")).toBe("file");
+  });
+});
+
+describe("formatFileRef", () => {
+  test("formats image reference", () => {
+    expect(formatFileRef("image", "/tmp/agent-town-uploads/abc-photo.png")).toBe(
+      "[image: /tmp/agent-town-uploads/abc-photo.png]",
+    );
+  });
+
+  test("formats file reference", () => {
+    expect(formatFileRef("file", "/tmp/agent-town-uploads/abc-doc.pdf")).toBe(
+      "[file: /tmp/agent-town-uploads/abc-doc.pdf]",
+    );
+  });
+});

--- a/dashboard/src/utils/file-upload.ts
+++ b/dashboard/src/utils/file-upload.ts
@@ -1,0 +1,38 @@
+import { API } from "../utils";
+
+const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
+
+interface UploadResult {
+  path: string;
+  filename: string;
+}
+
+export function getFileRefPrefix(mimeType: string): "image" | "file" {
+  return mimeType.startsWith("image/") ? "image" : "file";
+}
+
+export function formatFileRef(prefix: "image" | "file", path: string): string {
+  return `[${prefix}: ${path}]`;
+}
+
+export async function uploadFile(machineId: string, file: File): Promise<UploadResult> {
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    throw new Error(`File too large (${Math.round(file.size / 1024 / 1024)}MB). Max: 50MB`);
+  }
+
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const resp = await fetch(`${API.SESSIONS_UPLOAD}?machineId=${encodeURIComponent(machineId)}`, {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!resp.ok) {
+    const data = await resp.json().catch(() => ({ error: "Upload failed" }));
+    throw new Error((data as { error?: string }).error || `Upload failed (${resp.status})`);
+  }
+
+  const data: { ok: boolean; path: string; filename: string } = await resp.json();
+  return { path: data.path, filename: data.filename };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -479,6 +479,42 @@ async function routeRequest(
     }
   }
 
+  // API: upload a file to an agent machine (proxy to agent)
+  if (url.pathname === "/api/sessions/upload" && req.method === "POST") {
+    try {
+      const machineId = url.searchParams.get("machineId");
+      if (!machineId) {
+        return Response.json({ error: "Missing machineId query parameter" }, { status: 400 });
+      }
+
+      const machine = getMachine(machineId);
+      if (!machine || !machine.terminalPort) {
+        return Response.json({ error: "Machine not found" }, { status: 404 });
+      }
+
+      const agentUrl = getAgentUrl(machine, "/api/upload");
+      const contentType = req.headers.get("content-type");
+
+      const result = await proxyFetch(agentUrl, {
+        method: "POST",
+        headers: contentType ? { "content-type": contentType } : {},
+        body: req.body,
+        // @ts-expect-error Bun supports duplex on fetch
+        duplex: "half",
+      });
+
+      if (!result.ok) {
+        return Response.json({ error: result.error, message: result.message }, { status: result.status });
+      }
+
+      const data = await result.response.json();
+      return Response.json(data, { status: result.response.status });
+    } catch (err) {
+      log.error(`upload proxy: failed: ${err instanceof Error ? err.message : String(err)}`);
+      return Response.json({ error: "Failed to upload" }, { status: 500 });
+    }
+  }
+
   // API: reconnect agent in an existing mux session (proxy to agent)
   if (url.pathname === "/api/sessions/reconnect" && req.method === "POST") {
     try {


### PR DESCRIPTION
## Summary
- Add file upload endpoint to agent (`POST /api/upload`) with filename sanitization (UUID prefix, path traversal prevention), 50MB size limit, and temp dir cleanup
- Add server proxy endpoint (`POST /api/sessions/upload`) to forward uploads to agents via streaming
- Add drag-and-drop `FileDropZone` component with visual overlay, upload progress, and auto-dismissing errors
- Path references (`[image: /path]` for images, `[file: /path]` for others) are inserted into the chat input textarea for user review before sending
- `SendMessage` component now supports external text injection via `forwardRef` + `appendText()`

## Changes
- `agent/src/file-upload.ts` — Upload utilities: filename sanitization, size constants, old file cleanup
- `agent/src/terminal-server.ts` — New `POST /api/upload` endpoint with multipart form handling
- `server/src/index.ts` — New `POST /api/sessions/upload` proxy endpoint
- `dashboard/src/utils.ts` — Add `SESSIONS_UPLOAD` to API constants
- `dashboard/src/utils/file-upload.ts` — Client-side upload utility, MIME type detection, reference formatting
- `dashboard/src/components/FileDropZone.tsx` — Drag-and-drop wrapper with overlay/progress/error states
- `dashboard/src/components/SendMessage.tsx` — Add `forwardRef` + `useImperativeHandle` for `appendText`
- `dashboard/src/components/SessionDetail.tsx` — Integrate FileDropZone wrapping the main content area
- `dashboard/src/styles.css` — Drop zone overlay, progress, and error styles

## Test Plan
- [x] 13 agent file-upload tests (filename sanitization, size limits, cleanup)
- [x] 5 dashboard file-upload utility tests (MIME detection, reference formatting)
- [x] All 926 tests pass (908 existing + 18 new)
- [x] Biome lint clean
- [ ] Manual verification: drag file onto session, verify upload and chat input reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)