### PR TITLE
fix(server,dashboard): prevent website crash when remote node disconnects

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -368,6 +368,13 @@ export function App(): React.JSX.Element {
   const fullscreenMachine = fullscreen ? machines.find((m) => m.machineId === fullscreen.machineId) : null;
   const fullscreenSession = fullscreenMachine?.sessions.find((s) => s.sessionId === fullscreen?.sessionId) ?? null;
 
+  // Auto-close fullscreen if the machine or session disappeared (node disconnected)
+  useEffect(() => {
+    if (fullscreen && !fullscreenMachine) {
+      setFullscreen(null);
+    }
+  }, [fullscreen, fullscreenMachine]);
+
   const totalSessions = machines.reduce((sum, m) => sum + m.sessions.length, 0);
   const totalAttention = machines.reduce(
     (sum, m) => sum + m.sessions.filter((s) => s.status === "awaiting_input").length,

--- a/dashboard/src/components/ErrorBoundary.tsx
+++ b/dashboard/src/components/ErrorBoundary.tsx
@@ -1,0 +1,64 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error("ErrorBoundary caught:", error, errorInfo);
+  }
+
+  handleReload = (): void => {
+    window.location.reload();
+  };
+
+  handleDismiss = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="error-boundary">
+          <div className="error-boundary-content">
+            <h2 className="error-boundary-title">Something went wrong</h2>
+            <p className="error-boundary-message">
+              The dashboard encountered an unexpected error. This can happen when a remote machine disconnects.
+            </p>
+            {this.state.error && <pre className="error-boundary-detail">{this.state.error.message}</pre>}
+            <div className="error-boundary-actions">
+              <button type="button" className="send-btn" onClick={this.handleReload} aria-label="Reload the dashboard">
+                Reload
+              </button>
+              <button
+                type="button"
+                className="action-btn"
+                onClick={this.handleDismiss}
+                aria-label="Dismiss error and try to recover"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import "./styles.css";
 
 const rootElement = document.getElementById("root");
@@ -9,6 +10,8 @@ if (!rootElement) {
 }
 createRoot(rootElement).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -4707,3 +4707,48 @@ body {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   white-space: nowrap;
 }
+
+/* Error boundary */
+.error-boundary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  padding: 24px;
+}
+
+.error-boundary-content {
+  max-width: 480px;
+  text-align: center;
+}
+
+.error-boundary-title {
+  font-size: 20px;
+  margin-bottom: 12px;
+}
+
+.error-boundary-message {
+  color: var(--text-secondary);
+  margin-bottom: 16px;
+  line-height: 1.5;
+}
+
+.error-boundary-detail {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+  font-size: 12px;
+  text-align: left;
+  overflow-x: auto;
+  margin-bottom: 16px;
+  color: var(--error, #ef4444);
+}
+
+.error-boundary-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,6 +25,7 @@ import {
   getSessionSlug,
   getSettings,
   renameSession,
+  startStaleCleanupLoop,
   updateMultiplexerSessionName,
   updateNode,
   updateSettings,
@@ -956,3 +957,11 @@ log.info(`listening on http://0.0.0.0:${PORT} — dashboard: http://localhost:${
 
 // Auto-connect to nodes marked with autoConnect
 connectAutoNodes();
+
+// Periodically clean up stale machines and broadcast removals
+startStaleCleanupLoop(() => {
+  broadcast({
+    type: "machines_update",
+    payload: getAllMachines(),
+  });
+});

--- a/server/src/store.test.ts
+++ b/server/src/store.test.ts
@@ -917,4 +917,77 @@ describe("store", () => {
     const machine = getMachine("no-mux-placeholder");
     expect(machine?.sessions).toHaveLength(2);
   });
+
+  test("getMachine returns undefined for stale machine (past timeout)", () => {
+    const staleTimestamp = new Date(Date.now() - 60_000).toISOString();
+    upsertMachine(
+      makeHeartbeat({
+        machineId: "stale-machine-1",
+        hostname: "stale-host-1",
+        timestamp: staleTimestamp,
+      }),
+    );
+
+    const machine = getMachine("stale-machine-1");
+    expect(machine).toBeUndefined();
+  });
+
+  test("getMachine returns machine within timeout window", () => {
+    upsertMachine(
+      makeHeartbeat({
+        machineId: "fresh-machine-1",
+        hostname: "fresh-host-1",
+        timestamp: new Date().toISOString(),
+      }),
+    );
+
+    const machine = getMachine("fresh-machine-1");
+    expect(machine).not.toBeUndefined();
+    expect(machine?.hostname).toBe("fresh-host-1");
+  });
+
+  test("startStaleCleanupLoop calls broadcast when stale machines are removed", async () => {
+    const { startStaleCleanupLoop, stopStaleCleanupLoop } = await import("./store");
+
+    const staleTimestamp = new Date(Date.now() - 60_000).toISOString();
+    upsertMachine(
+      makeHeartbeat({
+        machineId: "cleanup-stale-1",
+        hostname: "cleanup-host-1",
+        timestamp: staleTimestamp,
+      }),
+    );
+
+    let broadcastCalled = false;
+    startStaleCleanupLoop(() => {
+      broadcastCalled = true;
+    }, 50);
+
+    await new Promise((r) => setTimeout(r, 120));
+    stopStaleCleanupLoop();
+
+    expect(broadcastCalled).toBe(true);
+  });
+
+  test("startStaleCleanupLoop does not broadcast when no machines removed", async () => {
+    const { startStaleCleanupLoop, stopStaleCleanupLoop } = await import("./store");
+
+    upsertMachine(
+      makeHeartbeat({
+        machineId: "cleanup-fresh-1",
+        hostname: "cleanup-fresh-host-1",
+        timestamp: new Date().toISOString(),
+      }),
+    );
+
+    let broadcastCalled = false;
+    startStaleCleanupLoop(() => {
+      broadcastCalled = true;
+    }, 50);
+
+    await new Promise((r) => setTimeout(r, 120));
+    stopStaleCleanupLoop();
+
+    expect(broadcastCalled).toBe(false);
+  });
 });

--- a/server/src/store.ts
+++ b/server/src/store.ts
@@ -321,7 +321,9 @@ export function getMachine(machineId: string): MachineInfo | undefined {
   const lastSeen = new Date(machine.lastHeartbeat).getTime();
   if (Date.now() - lastSeen > MACHINE_TIMEOUT_MS) {
     machines.delete(machineId);
-    log.debug(`getMachine: removed stale machine ${machineId.slice(0, 8)} (no heartbeat for ${Math.round((Date.now() - lastSeen) / 1000)}s)`);
+    log.debug(
+      `getMachine: removed stale machine ${machineId.slice(0, 8)} (no heartbeat for ${Math.round((Date.now() - lastSeen) / 1000)}s)`,
+    );
     return undefined;
   }
 

--- a/server/src/store.ts
+++ b/server/src/store.ts
@@ -315,7 +315,41 @@ export function getAllMachines(): MachineInfo[] {
 }
 
 export function getMachine(machineId: string): MachineInfo | undefined {
-  return machines.get(machineId);
+  const machine = machines.get(machineId);
+  if (!machine) return undefined;
+
+  const lastSeen = new Date(machine.lastHeartbeat).getTime();
+  if (Date.now() - lastSeen > MACHINE_TIMEOUT_MS) {
+    machines.delete(machineId);
+    log.debug(`getMachine: removed stale machine ${machineId.slice(0, 8)} (no heartbeat for ${Math.round((Date.now() - lastSeen) / 1000)}s)`);
+    return undefined;
+  }
+
+  return machine;
+}
+
+let cleanupInterval: ReturnType<typeof setInterval> | null = null;
+
+export function startStaleCleanupLoop(broadcastFn: () => void, intervalMs = 10_000): void {
+  if (cleanupInterval) return;
+
+  cleanupInterval = setInterval(() => {
+    const before = machines.size;
+    getAllMachines();
+    const after = machines.size;
+
+    if (after < before) {
+      log.info(`stale cleanup: removed ${before - after} machine(s), broadcasting update`);
+      broadcastFn();
+    }
+  }, intervalMs);
+}
+
+export function stopStaleCleanupLoop(): void {
+  if (cleanupInterval) {
+    clearInterval(cleanupInterval);
+    cleanupInterval = null;
+  }
 }
 
 // Settings store


### PR DESCRIPTION
## Summary
- **Root cause**: When a remote node disconnects, the server kept stale machine references in memory for 30s. During that window, proxy requests to the dead agent hung for 10s (timeout), and the dashboard had no error boundary to recover from cascading failures.
- **Fix**: Three-layer defense:
  1. `getMachine()` now rejects stale machines (past 30s heartbeat timeout), preventing proxy requests from ever reaching dead agents
  2. Periodic cleanup loop (every 10s) removes stale machines and broadcasts the updated list to all dashboard clients via WebSocket
  3. React `ErrorBoundary` catches any remaining crashes and shows a recovery UI instead of a blank page
  4. Dashboard auto-closes fullscreen view when the selected machine disappears

## Changes
- `server/src/store.ts` — `getMachine()` staleness check, `startStaleCleanupLoop()` / `stopStaleCleanupLoop()` for periodic cleanup with broadcast
- `server/src/index.ts` — Start cleanup loop on server startup, import new exports
- `dashboard/src/components/ErrorBoundary.tsx` — New React error boundary with Reload/Dismiss actions
- `dashboard/src/main.tsx` — Wrap `<App>` with `<ErrorBoundary>`
- `dashboard/src/App.tsx` — Auto-close fullscreen when machine disappears
- `dashboard/src/styles.css` — Error boundary styling

## Test Plan
- [x] `getMachine` returns undefined for stale machines (past timeout)
- [x] `getMachine` returns machine within timeout window
- [x] `startStaleCleanupLoop` calls broadcast when stale machines are removed
- [x] `startStaleCleanupLoop` does not broadcast when no machines removed
- [x] All 950 tests pass (946 existing + 4 new)
- [x] Biome lint clean
- [ ] Manual: disconnect a remote node, verify dashboard stays functional and shows updated machine list

🤖 Generated with [Claude Code](https://claude.com/claude-code)